### PR TITLE
Add Postgres Support

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -12,7 +12,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
-	_ "github.com/jackc/pgx/v4"
+	_ "github.com/jackc/pgx/v4/stdlib"
 	"go.uber.org/zap"
 
 	"github.com/app-sre/gabi/pkg/env/db"

--- a/pkg/env/db/db.go
+++ b/pkg/env/db/db.go
@@ -61,7 +61,16 @@ func (dbe *Dbenv) Populate() error {
 	dbe.DB_NAME = name
 	dbe.DB_WRITE = write
 
-	dbe.ConnStr = fmt.Sprintf("%s:%s@tcp(%s:%s)/%s",
+	var connStringFmt string
+
+	switch driver {
+	case "mysql":
+		connStringFmt = "%s:%s@tcp(%s:%s)/%s"
+	case "pgx":
+		connStringFmt = "postgres://%s:%s@%s:%s/%s"
+	}
+
+	dbe.ConnStr = fmt.Sprintf(connStringFmt,
 		dbe.DB_USER,
 		dbe.DB_PASS,
 		dbe.DB_HOST,


### PR DESCRIPTION
This MR fixes the usage of `pgx` in gabi. The driver is imported from pgx/v4/stdlib to support usage with sql.DB interface. In addition, the constructed connection string now changes format depending on the database type specified in runtime environment variables.
