### PR TITLE
Add Audit Support

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=

--- a/pkg/audit/audit.go
+++ b/pkg/audit/audit.go
@@ -1,0 +1,24 @@
+package audit
+
+import (
+	"time"
+
+	gabi "github.com/app-sre/gabi/pkg"
+)
+
+// stdout logging (json format, with "query", "user", "ts" values).
+type Audit interface {
+	write(QueryMetadata) error
+}
+
+type QueryMetadata struct {
+	timestamp time.Time
+	query     string
+	user      string
+}
+
+func LogAudit(env *gabi.Env, q *QueryMetadata) error {
+
+}
+
+func CloudwatchAudit() error

--- a/pkg/audit/audit.go
+++ b/pkg/audit/audit.go
@@ -1,24 +1,34 @@
 package audit
 
 import (
-	"time"
-
-	gabi "github.com/app-sre/gabi/pkg"
+	"go.uber.org/zap"
 )
 
-// stdout logging (json format, with "query", "user", "ts" values).
+type QueryData struct {
+	Query     string
+	User      string
+	Timestamp int64
+}
+
 type Audit interface {
-	write(QueryMetadata) error
+	Write(*QueryData) error
 }
 
-type QueryMetadata struct {
-	timestamp time.Time
-	query     string
-	user      string
+type LoggingAudit struct {
+	Logger *zap.SugaredLogger
 }
 
-func LogAudit(env *gabi.Env, q *QueryMetadata) error {
-
+func (d *LoggingAudit) Write(q *QueryData) error {
+	d.Logger.Infow("gabi API audit record",
+		"Query", q.Query,
+		"User", q.User,
+		"Timestamp", q.Timestamp,
+	)
+	return nil
 }
 
-func CloudwatchAudit() error
+type CloudwatchAudit struct{}
+
+func (c *CloudwatchAudit) Write(q *QueryData) error {
+	return nil
+}

--- a/pkg/gabi.go
+++ b/pkg/gabi.go
@@ -3,6 +3,7 @@ package gabi
 import (
 	"database/sql"
 
+	"github.com/app-sre/gabi/pkg/audit"
 	"go.uber.org/zap"
 )
 
@@ -11,4 +12,5 @@ const Version = "0.0.1"
 type Env struct {
 	DB     *sql.DB
 	Logger *zap.SugaredLogger
+	Audit  audit.Audit
 }


### PR DESCRIPTION
This PR adds flexible audit support to gabi. Users wishing to add a different audit backend will need to add a struct which implements the Audit.Write() interface. Currently, only stdout logging is supported, with plans in the future to add CloudWatch audit support.

The audit interface is included in gabi's Env struct, which also houses the DB connection pool and logger for passing to handlers.

`2021-07-12T17:15:59.984-0700	INFO	audit/audit.go:22	gabi API audit record	{"Query": "SELECT * FROM company;", "User": "placeholder", "Timestamp": 1626135359}`