### PR TITLE
[APPSRE-4546] Address healthcheck secret leak

### DIFF
--- a/pkg/handlers/healthcheck.go
+++ b/pkg/handlers/healthcheck.go
@@ -2,7 +2,10 @@ package handlers
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
+	"log"
 	"time"
 
 	"github.com/etherlabsio/healthcheck/v2"
@@ -16,7 +19,14 @@ func Healthcheck(env *gabi.Env) http.Handler {
 		healthcheck.WithChecker(
 			"database", healthcheck.CheckerFunc(
 				func(ctx context.Context) error {
-					return env.DB.PingContext(ctx)
+					err := env.DB.PingContext(ctx)
+						if err != nil {
+							errStr := "failed to connect to database as part of healthcheck ping"
+							logErr := fmt.Errorf(errStr + ": %v", err)
+							log.Println(logErr)
+							return errors.New("failed to connect database... see gabi logs for further details")
+					}
+					return nil // healthcheck passed successfully
 				},
 			),
 		),

--- a/pkg/handlers/healthcheck.go
+++ b/pkg/handlers/healthcheck.go
@@ -20,11 +20,11 @@ func Healthcheck(env *gabi.Env) http.Handler {
 			"database", healthcheck.CheckerFunc(
 				func(ctx context.Context) error {
 					err := env.DB.PingContext(ctx)
-						if err != nil {
-							errStr := "failed to connect to database as part of healthcheck ping"
-							logErr := fmt.Errorf(errStr + ": %v", err)
-							log.Println(logErr)
-							return errors.New("failed to connect database... see gabi logs for further details")
+					if err != nil {
+						errStr := "failed to connect to database as part of healthcheck ping"
+						logErr := fmt.Errorf(errStr + ": %v", err)
+						log.Println(logErr)
+						return errors.New("failed to connect database... see gabi logs for further details")
 					}
 					return nil // healthcheck passed successfully
 				},


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-4546

This PR updates the behavior of Gabi's healthcheck to only print a secret-containing SQL connection string in its logs and not in the HTTP response.

Those with access to gabi logs will still be able to see these secrets.