### PR TITLE
URL encode DB_PASS for pgx driver connection

### DIFF
--- a/pkg/env/db/db.go
+++ b/pkg/env/db/db.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 
@@ -68,6 +69,7 @@ func (dbe *Dbenv) Populate() error {
 		connStringFmt = "%s:%s@tcp(%s:%s)/%s"
 	case "pgx":
 		connStringFmt = "postgres://%s:%s@%s:%s/%s"
+		dbe.DB_PASS = url.PathEscape(dbe.DB_PASS) // only do this for pgx driver bc mysql driver will handle encoding
 	}
 
 	dbe.ConnStr = fmt.Sprintf(connStringFmt,


### PR DESCRIPTION
ISSUE:
When utilizing the pgx driver, special characters within DB_PASS caused the connection to fail. 

SOLUTION:
URL encode DB_PASS prior to creating the connection string. 
Note: this is not included in mysql because the mysql driver handles encoding differently and will fail connection if encoded.

Ticket: https://issues.redhat.com/browse/APPSRE-4548