### PR TITLE
enable read-only transaction if db is not writeable

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -57,7 +57,7 @@ func Run(logger *zap.SugaredLogger) {
 	logger.Info("Database connection handle established.")
 	logger.Infof("Using %s database driver.", dbe.DB_DRIVER)
 
-	env := &gabi.Env{DB: db, Logger: logger, Audit: a, SplunkAudit: *s, Users: usere.Users}
+	env := &gabi.Env{DB: db, DB_WRITE: dbe.DB_WRITE, Logger: logger, Audit: a, SplunkAudit: *s, Users: usere.Users}
 
 	r := mux.NewRouter()
 

--- a/pkg/gabi.go
+++ b/pkg/gabi.go
@@ -11,6 +11,7 @@ const Version = "0.0.1"
 
 type Env struct {
 	DB          *sql.DB
+	DB_WRITE    bool
 	Logger      *zap.SugaredLogger
 	Audit       audit.Audit
 	SplunkAudit audit.SplunkAudit


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-4653

```
~ curl 'http://localhost:8080/query' \             
--H 'X-Forwarded-User: fehuang' \
-d '{
    "Query":"DROP TABLE test;"
}'

ERROR: cannot execute DROP TABLE in a read-only transaction (SQLSTATE 25006)
```


Signed-off-by: Feng Huang <fehuang@redhat.com>