### PR TITLE
add error handling for instance expiration

### DIFF
--- a/openshift/gabi-no-cluster-resources.template.yaml
+++ b/openshift/gabi-no-cluster-resources.template.yaml
@@ -112,6 +112,11 @@ objects:
                 name: ${AWS_RDS_SECRET_NAME}
           - name: USERS_FILE_PATH
             value: ${USERS_FILE_PATH}
+          - name: INSTANCE_EXPIRATION
+            valueFrom:
+              configMapKeyRef:
+                name: ${USERS_CONFIGMAP_NAME}
+                key: expiration
           resources:
             requests:
               cpu: 100m

--- a/openshift/gabi.template.yaml
+++ b/openshift/gabi.template.yaml
@@ -141,6 +141,11 @@ objects:
                 name: ${AWS_RDS_SECRET_NAME}
           - name: USERS_FILE_PATH
             value: ${USERS_FILE_PATH}
+          - name: INSTANCE_EXPIRATION
+            valueFrom:
+              configMapKeyRef:
+                name: ${USERS_CONFIGMAP_NAME}
+                key: expiration
           resources:
             requests:
               cpu: 100m

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -57,7 +57,7 @@ func Run(logger *zap.SugaredLogger) {
 	logger.Info("Database connection handle established.")
 	logger.Infof("Using %s database driver.", dbe.DB_DRIVER)
 
-	env := &gabi.Env{DB: db, DB_WRITE: dbe.DB_WRITE, Logger: logger, Audit: a, SplunkAudit: *s, Users: usere.Users}
+	env := &gabi.Env{DB: db, DB_WRITE: dbe.DB_WRITE, Logger: logger, Audit: a, SplunkAudit: *s, Users: usere.Users, Expiration: usere.Expiration}
 
 	r := mux.NewRouter()
 

--- a/pkg/env/user/user.go
+++ b/pkg/env/user/user.go
@@ -3,12 +3,14 @@ package user
 import (
 	"bufio"
 	"os"
+	"time"
 
 	"github.com/app-sre/gabi/pkg/env"
 )
 
 type Userenv struct {
 	Users []string
+	Expiration time.Time
 }
 
 func (usere *Userenv) Populate() error {
@@ -31,6 +33,16 @@ func (usere *Userenv) Populate() error {
 
 	if err := scanner.Err(); err != nil {
 		return err
+	}
+
+	expiration, found := os.LookupEnv("INSTANCE_EXPIRATION")
+	if !(found) {
+		return &env.EnvError{Env: "INSTANCE_EXPIRATION"}
+	}
+	if parsed_expiration, err := time.Parse("2006-01-02", expiration); err != nil {
+		return err
+	} else {
+		usere.Expiration = parsed_expiration
 	}
 
 	return nil

--- a/pkg/gabi.go
+++ b/pkg/gabi.go
@@ -1,6 +1,7 @@
 package gabi
 
 import (
+	"time"
 	"database/sql"
 
 	"github.com/app-sre/gabi/pkg/audit"
@@ -16,4 +17,5 @@ type Env struct {
 	Audit       audit.Audit
 	SplunkAudit audit.SplunkAudit
 	Users       []string
+	Expiration	time.Time
 }

--- a/pkg/handlers/query.go
+++ b/pkg/handlers/query.go
@@ -44,6 +44,10 @@ func Query(env *gabi.Env) http.HandlerFunc {
 		}
 
 		now := time.Now()
+		if now.After(env.Expiration) {
+			http.Error(w, "Instance expired", http.StatusUnauthorized)
+			return
+		}
 		user := r.Header.Get("X-Forwarded-User")
 		if user == "" || !stringInSlice(user, env.Users) {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)


### PR DESCRIPTION
when a user attempts to query a Gabi instance, they may not be authorized, or the expiration for the instance had passed:
https://github.com/app-sre/gabi/blob/b4be98ac40fe91c7911f4347339b8ddc7db9e0ee/pkg/handlers/query.go#L49

there is little we can say in addition to "Unauthorized" when a user is unauthorized, but we could check for the instance expiration and output a more informative message.

this PR adds the output message about expiration. this depends on the expiration being in the ConfigMap, which is implemented in https://github.com/app-sre/qontract-reconcile/pull/2364

note: the ConfigMap name, or the way we reference it (users) now holds information that can be more generally called "auth". to avoid additional refactoring, i've decided to keep the naming as "users", and will keep any required refactor for a future iteration. one could argue that the expiration is really about the users, since the instance itself doesn't expire, but only the user access to it. open for other opinions here.