### PR TITLE
increase t/o for queries

### DIFF
--- a/openshift/gabi-no-cluster-resources.template.yaml
+++ b/openshift/gabi-no-cluster-resources.template.yaml
@@ -145,7 +145,9 @@ objects:
   kind: Route
   metadata:
     annotations:
-      kubernetes.io/tls-acme: "true"    
+      kubernetes.io/tls-acme: "true"
+      # https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.1/html/managing_and_monitoring_process_server/configuring-openshift-connection-timeout-proc
+      haproxy.router.openshift.io/timeout: ${SERVER_TIMEOUT}
     name: gabi
   spec:
     host: ${HOST}
@@ -165,6 +167,8 @@ parameters:
   value: latest
 - name: REPLICAS
   value: "1"
+- name: SERVER_TIMEOUT
+  value: 30s
 - name: OAUTH_PROXY_IMAGE_NAME
   value: quay.io/openshift/origin-oauth-proxy
 - name: OAUTH_PROXY_IMAGE_TAG

--- a/openshift/gabi.template.yaml
+++ b/openshift/gabi.template.yaml
@@ -175,6 +175,8 @@ objects:
   metadata:
     annotations:
       kubernetes.io/tls-acme: "true"    
+      # https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.1/html/managing_and_monitoring_process_server/configuring-openshift-connection-timeout-proc
+      haproxy.router.openshift.io/timeout: ${SERVER_TIMEOUT}
     name: gabi
   spec:
     host: ${HOST}
@@ -194,6 +196,8 @@ parameters:
   value: latest
 - name: REPLICAS
   value: "1"
+- name: SERVER_TIMEOUT
+  value: 30s
 - name: OAUTH_PROXY_IMAGE_NAME
   value: quay.io/openshift/origin-oauth-proxy
 - name: OAUTH_PROXY_IMAGE_TAG


### PR DESCRIPTION
Customer is trying to execute a long running query with `http --timeout 600`. I assume we wont have much traffic here, so allowing this might be ok?