### PR TITLE
adding parameter to resource name to allow for multiple instances

### DIFF
--- a/openshift/gabi-no-cluster-resources.template.yaml
+++ b/openshift/gabi-no-cluster-resources.template.yaml
@@ -162,7 +162,7 @@ objects:
         volumes:
         - name: gabi-tls
           secret:
-            secretName: gabi-tls
+            secretName: ${GABI_INSTANCE}-tls
         - name: gabi-users
           configMap:
             optional: true

--- a/openshift/gabi-no-cluster-resources.template.yaml
+++ b/openshift/gabi-no-cluster-resources.template.yaml
@@ -1,33 +1,33 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: gabi
+  name: ${Identifier}
 objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
-    name: gabi
+    name: ${Identifier}
     annotations:
       serviceaccounts.openshift.io/oauth-redirectreference.prometheus: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"gabi"}}'
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:
-      app: gabi
-    name: gabi
+      app: ${Identifier}
+    name: ${Identifier}
     annotations:
       ignore-check.kube-linter.io/minimum-three-replicas: "Gabi does not need 3 replicas"
   spec:
     replicas: ${{REPLICAS}}
     selector:
       matchLabels:
-        app: gabi
+        app: ${Identifier}
     template:
       metadata:
         labels:
-          app: gabi
+          app: ${Identifier}
       spec:
-        serviceAccountName: gabi
+        serviceAccountName: ${Identifier}
         containers:
         - name: oauth-proxy
           image: ${OAUTH_PROXY_IMAGE_NAME}:${OAUTH_PROXY_IMAGE_TAG}
@@ -76,7 +76,7 @@ objects:
           - mountPath: /etc/tls/private
             name: gabi-tls
         - image: quay.io/app-sre/gabi:${IMAGE_TAG}
-          name: gabi
+          name: ${Identifier}
           readinessProbe:
             httpGet:
               path: /healthcheck
@@ -166,11 +166,11 @@ objects:
         - name: gabi-users
           configMap:
             optional: true
-            name: ${USERS_CONFIGMAP_NAME}
+            name: ${GABI_INSTANCE}
 - apiVersion: v1
   kind: Service
   metadata:
-    name: gabi
+    name: ${Identifier}
     annotations:
       service.alpha.openshift.io/serving-cert-secret-name: gabi-tls
   spec:
@@ -180,7 +180,7 @@ objects:
       protocol: TCP
       targetPort: http
     selector:
-      app: gabi
+      app: ${Identifier}
 - apiVersion: route.openshift.io/v1
   kind: Route
   metadata:
@@ -189,17 +189,17 @@ objects:
       cert-manager.io/issuer-name: ${{CERT_MANAGER_ISSUER_NAME}}
       # https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.1/html/managing_and_monitoring_process_server/configuring-openshift-connection-timeout-proc
       haproxy.router.openshift.io/timeout: ${SERVER_TIMEOUT}
-    name: gabi
+    name: ${Identifier}
   spec:
     host: ${HOST}
     port:
       targetPort: http
     to:
       kind: Service
-      name: gabi
+      name: ${Identifier}
       weight: 100
     tls:
-      termination: Reencrypt
+      termination: reencrypt
       insecureEdgeTerminationPolicy: Redirect
 parameters:
 - name: NAMESPACE
@@ -228,11 +228,13 @@ parameters:
   value: gabi-staging
 - name: SPLUNK_SECRET_NAME
   value: splunk-creds
-- name: USERS_CONFIGMAP_NAME
-  value: gabi-authorized-users
+- name: GABI_INSTANCE
+  value: gabi-instance
 - name: USERS_FILE_PATH
   value: /config/authorized-users.yaml
 - name: CERT_MANAGER_ISSUER_KIND
   value: ClusterIssuer
 - name: CERT_MANAGER_ISSUER_NAME
   value: letsencrypt-prod-http
+- name: Identifier
+  value: gabi

--- a/openshift/gabi-no-cluster-resources.template.yaml
+++ b/openshift/gabi-no-cluster-resources.template.yaml
@@ -8,7 +8,7 @@ objects:
   metadata:
     name: ${GABI_INSTANCE}
     annotations:
-      serviceaccounts.openshift.io/oauth-redirectreference.prometheus: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"gabi"}}'
+      serviceaccounts.openshift.io/oauth-redirectreference.prometheus: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"${GABI_INSTANCE}"}}'
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -170,7 +170,7 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    name: ${GABI_INSTANCE}
+    name: ${GABI_INSTANCE}-tls
     annotations:
       service.alpha.openshift.io/serving-cert-secret-name: gabi-tls
   spec:

--- a/openshift/gabi-no-cluster-resources.template.yaml
+++ b/openshift/gabi-no-cluster-resources.template.yaml
@@ -66,7 +66,7 @@ objects:
           args:
           - --https-address=:3000
           - --provider=openshift
-          - --openshift-service-account=gabi
+          - --openshift-service-account=${GABI_INSTANCE}
           - --upstream=http://localhost:8080
           - '--openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}", "namespace": "${NAMESPACE}"}}'
           - --tls-cert=/etc/tls/private/tls.crt
@@ -170,9 +170,9 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    name: ${GABI_INSTANCE}-tls
+    name: ${GABI_INSTANCE}
     annotations:
-      service.alpha.openshift.io/serving-cert-secret-name: gabi-tls
+      service.alpha.openshift.io/serving-cert-secret-name: ${GABI_INSTANCE}-tls
   spec:
     ports:
     - name: http

--- a/openshift/gabi-no-cluster-resources.template.yaml
+++ b/openshift/gabi-no-cluster-resources.template.yaml
@@ -1,33 +1,33 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: ${Identifier}
+  name: ${GABI_INSTANCE}
 objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
-    name: ${Identifier}
+    name: ${GABI_INSTANCE}
     annotations:
       serviceaccounts.openshift.io/oauth-redirectreference.prometheus: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"gabi"}}'
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:
-      app: ${Identifier}
-    name: ${Identifier}
+      app: ${GABI_INSTANCE}
+    name: ${GABI_INSTANCE}
     annotations:
       ignore-check.kube-linter.io/minimum-three-replicas: "Gabi does not need 3 replicas"
   spec:
     replicas: ${{REPLICAS}}
     selector:
       matchLabels:
-        app: ${Identifier}
+        app: ${GABI_INSTANCE}
     template:
       metadata:
         labels:
-          app: ${Identifier}
+          app: ${GABI_INSTANCE}
       spec:
-        serviceAccountName: ${Identifier}
+        serviceAccountName: ${GABI_INSTANCE}
         containers:
         - name: oauth-proxy
           image: ${OAUTH_PROXY_IMAGE_NAME}:${OAUTH_PROXY_IMAGE_TAG}
@@ -76,7 +76,7 @@ objects:
           - mountPath: /etc/tls/private
             name: gabi-tls
         - image: quay.io/app-sre/gabi:${IMAGE_TAG}
-          name: ${Identifier}
+          name: ${GABI_INSTANCE}
           readinessProbe:
             httpGet:
               path: /healthcheck
@@ -170,7 +170,7 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    name: ${Identifier}
+    name: ${GABI_INSTANCE}
     annotations:
       service.alpha.openshift.io/serving-cert-secret-name: gabi-tls
   spec:
@@ -180,7 +180,7 @@ objects:
       protocol: TCP
       targetPort: http
     selector:
-      app: ${Identifier}
+      app: ${GABI_INSTANCE}
 - apiVersion: route.openshift.io/v1
   kind: Route
   metadata:
@@ -189,14 +189,14 @@ objects:
       cert-manager.io/issuer-name: ${{CERT_MANAGER_ISSUER_NAME}}
       # https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.1/html/managing_and_monitoring_process_server/configuring-openshift-connection-timeout-proc
       haproxy.router.openshift.io/timeout: ${SERVER_TIMEOUT}
-    name: ${Identifier}
+    name: ${GABI_INSTANCE}
   spec:
     host: ${HOST}
     port:
       targetPort: http
     to:
       kind: Service
-      name: ${Identifier}
+      name: ${GABI_INSTANCE}
       weight: 100
     tls:
       termination: reencrypt
@@ -236,5 +236,3 @@ parameters:
   value: ClusterIssuer
 - name: CERT_MANAGER_ISSUER_NAME
   value: letsencrypt-prod-http
-- name: Identifier
-  value: gabi

--- a/openshift/gabi.template.yaml
+++ b/openshift/gabi.template.yaml
@@ -187,7 +187,7 @@ objects:
         volumes:
         - name: gabi-tls
           secret:
-            secretName: gabi-tls
+            secretName: ${GABI_INSTANCE}-tls
         - name: gabi-users
           configMap:
             optional: true

--- a/openshift/gabi.template.yaml
+++ b/openshift/gabi.template.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: ${Identifier}
+  name: ${GABI_INSTANCE}
 objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
-    name: ${Identifier}
+    name: ${GABI_INSTANCE}
     annotations:
       serviceaccounts.openshift.io/oauth-redirectreference.prometheus: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"gabi"}}'
 - apiVersion: rbac.authorization.k8s.io/v1
@@ -32,7 +32,7 @@ objects:
     name: openshift-oauth-delegate-gabi-${NAMESPACE}
   subjects:
     - kind: ServiceAccount
-      name: ${Identifier}
+      name: ${GABI_INSTANCE}
       namespace: ${NAMESPACE}
   roleRef:
     kind: ClusterRole
@@ -42,21 +42,21 @@ objects:
   kind: Deployment
   metadata:
     labels:
-      app: ${Identifier}
-    name: ${Identifier}
+      app: ${GABI_INSTANCE}
+    name: ${GABI_INSTANCE}
     annotations:
       ignore-check.kube-linter.io/minimum-three-replicas: "Gabi does not need 3 replicas"
   spec:
     replicas: ${{REPLICAS}}
     selector:
       matchLabels:
-        app: ${Identifier}
+        app: ${GABI_INSTANCE}
     template:
       metadata:
         labels:
-          app: ${Identifier}
+          app: ${GABI_INSTANCE}
       spec:
-        serviceAccountName: ${Identifier}
+        serviceAccountName: ${GABI_INSTANCE}
         containers:
         - name: oauth-proxy
           image: ${OAUTH_PROXY_IMAGE_NAME}:${OAUTH_PROXY_IMAGE_TAG}
@@ -103,7 +103,7 @@ objects:
           - mountPath: /etc/tls/private
             name: gabi-tls
         - image: quay.io/app-sre/gabi:${IMAGE_TAG}
-          name: ${Identifier}
+          name: ${GABI_INSTANCE}
           readinessProbe:
             httpGet:
               path: /healthcheck
@@ -195,7 +195,7 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    name: ${Identifier}
+    name: ${GABI_INSTANCE}
     annotations:
       service.alpha.openshift.io/serving-cert-secret-name: gabi-tls
   spec:
@@ -205,7 +205,7 @@ objects:
       protocol: TCP
       targetPort: http
     selector:
-      app: ${Identifier}
+      app: ${GABI_INSTANCE}
 - apiVersion: route.openshift.io/v1
   kind: Route
   metadata:
@@ -214,14 +214,14 @@ objects:
       cert-manager.io/issuer-name: ${{CERT_MANAGER_ISSUER_NAME}}
       # https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.1/html/managing_and_monitoring_process_server/configuring-openshift-connection-timeout-proc
       haproxy.router.openshift.io/timeout: ${SERVER_TIMEOUT}
-    name: ${Identifier}
+    name: ${GABI_INSTANCE}
   spec:
     host: ${HOST}
     port:
       targetPort: http
     to:
       kind: Service
-      name: ${Identifier}
+      name: ${GABI_INSTANCE}
       weight: 100
     tls:
       termination: reencrypt
@@ -261,5 +261,3 @@ parameters:
   value: ClusterIssuer
 - name: CERT_MANAGER_ISSUER_NAME
   value: letsencrypt-prod-http
-- name: Identifier
-  value: gabi

--- a/openshift/gabi.template.yaml
+++ b/openshift/gabi.template.yaml
@@ -8,7 +8,7 @@ objects:
   metadata:
     name: ${GABI_INSTANCE}
     annotations:
-      serviceaccounts.openshift.io/oauth-redirectreference.prometheus: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"gabi"}}'
+      serviceaccounts.openshift.io/oauth-redirectreference.prometheus: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"${GABI_INSTANCE}"}}'
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
@@ -93,7 +93,7 @@ objects:
           args:
           - --https-address=:3000
           - --provider=openshift
-          - --openshift-service-account=gabi
+          - --openshift-service-account=${GABI_INSTANCE}
           - --upstream=http://localhost:8080
           - '--openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}", "namespace": "${NAMESPACE}"}}'
           - --tls-cert=/etc/tls/private/tls.crt
@@ -197,7 +197,7 @@ objects:
   metadata:
     name: ${GABI_INSTANCE}
     annotations:
-      service.alpha.openshift.io/serving-cert-secret-name: gabi-tls
+      service.alpha.openshift.io/serving-cert-secret-name: ${GABI_INSTANCE}-tls
   spec:
     ports:
     - name: http

--- a/openshift/gabi.template.yaml
+++ b/openshift/gabi.template.yaml
@@ -43,7 +43,7 @@ objects:
   metadata:
     labels:
       app: gabi
-    name: gabi
+    name: ${identifier}
     annotations:
       ignore-check.kube-linter.io/minimum-three-replicas: "Gabi does not need 3 replicas"
   spec:
@@ -261,3 +261,5 @@ parameters:
   value: ClusterIssuer
 - name: CERT_MANAGER_ISSUER_NAME
   value: letsencrypt-prod-http
+- name: identifier
+  value: gabi

--- a/openshift/gabi.template.yaml
+++ b/openshift/gabi.template.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: gabi
+  name: ${Identifier}
 objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
-    name: gabi
+    name: ${Identifier}
     annotations:
       serviceaccounts.openshift.io/oauth-redirectreference.prometheus: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"gabi"}}'
 - apiVersion: rbac.authorization.k8s.io/v1
@@ -32,7 +32,7 @@ objects:
     name: openshift-oauth-delegate-gabi-${NAMESPACE}
   subjects:
     - kind: ServiceAccount
-      name: gabi
+      name: ${Identifier}
       namespace: ${NAMESPACE}
   roleRef:
     kind: ClusterRole
@@ -42,21 +42,21 @@ objects:
   kind: Deployment
   metadata:
     labels:
-      app: gabi
-    name: ${identifier}
+      app: ${Identifier}
+    name: ${Identifier}
     annotations:
       ignore-check.kube-linter.io/minimum-three-replicas: "Gabi does not need 3 replicas"
   spec:
     replicas: ${{REPLICAS}}
     selector:
       matchLabels:
-        app: gabi
+        app: ${Identifier}
     template:
       metadata:
         labels:
-          app: gabi
+          app: ${Identifier}
       spec:
-        serviceAccountName: gabi
+        serviceAccountName: ${Identifier}
         containers:
         - name: oauth-proxy
           image: ${OAUTH_PROXY_IMAGE_NAME}:${OAUTH_PROXY_IMAGE_TAG}
@@ -103,7 +103,7 @@ objects:
           - mountPath: /etc/tls/private
             name: gabi-tls
         - image: quay.io/app-sre/gabi:${IMAGE_TAG}
-          name: gabi
+          name: ${Identifier}
           readinessProbe:
             httpGet:
               path: /healthcheck
@@ -191,11 +191,11 @@ objects:
         - name: gabi-users
           configMap:
             optional: true
-            name: ${USERS_CONFIGMAP_NAME}
+            name: ${GABI_INSTANCE}
 - apiVersion: v1
   kind: Service
   metadata:
-    name: gabi
+    name: ${Identifier}
     annotations:
       service.alpha.openshift.io/serving-cert-secret-name: gabi-tls
   spec:
@@ -205,7 +205,7 @@ objects:
       protocol: TCP
       targetPort: http
     selector:
-      app: gabi
+      app: ${Identifier}
 - apiVersion: route.openshift.io/v1
   kind: Route
   metadata:
@@ -214,17 +214,17 @@ objects:
       cert-manager.io/issuer-name: ${{CERT_MANAGER_ISSUER_NAME}}
       # https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.1/html/managing_and_monitoring_process_server/configuring-openshift-connection-timeout-proc
       haproxy.router.openshift.io/timeout: ${SERVER_TIMEOUT}
-    name: gabi
+    name: ${Identifier}
   spec:
     host: ${HOST}
     port:
       targetPort: http
     to:
       kind: Service
-      name: gabi
+      name: ${Identifier}
       weight: 100
     tls:
-      termination: Reencrypt
+      termination: reencrypt
       insecureEdgeTerminationPolicy: Redirect
 parameters:
 - name: NAMESPACE
@@ -253,13 +253,13 @@ parameters:
   value: gabi-staging
 - name: SPLUNK_SECRET_NAME
   value: splunk-creds
-- name: USERS_CONFIGMAP_NAME
-  value: gabi-authorized-users
+- name: GABI_INSTANCE
+  value: gabi-instance
 - name: USERS_FILE_PATH
   value: /config/authorized-users.yaml
 - name: CERT_MANAGER_ISSUER_KIND
   value: ClusterIssuer
 - name: CERT_MANAGER_ISSUER_NAME
   value: letsencrypt-prod-http
-- name: identifier
+- name: Identifier
   value: gabi


### PR DESCRIPTION
Right now, we cannot deploy multiple gabi instances to the same namespace. If we parameterize the resource name for gabi, we can achieve this goal.

Signed-off-by: Suzana Nesic <snesic@redhat.com>