### PR TITLE
Embed the splunk creds data in the variable instead of relying on an external secret

### DIFF
--- a/openshift/gabi.template.yaml
+++ b/openshift/gabi.template.yaml
@@ -115,12 +115,12 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SPLUNK_TOKEN
-                name: splunk
+                name: ${GABI_INSTANCE}-splunk
           - name: SPLUNK_ENDPOINT
             valueFrom:
               secretKeyRef:
                 key: SPLUNK_ENDPOINT
-                name: splunk
+                name: ${GABI_INSTANCE}-splunk
           - name: DB_DRIVER
             value: ${DB_DRIVER}
           - name: DB_WRITE
@@ -168,13 +168,13 @@ objects:
             optional: true
             name: ${GABI_INSTANCE}
 - apiVersion: v1
-  data:
-    SPLUNK_TOKEN: ${SPLUNK_TOKEN}
-    SPLUNK_ENDPOINT: ${SPLUNK_ENDPOINT}
   kind: Secret
   metadata:
-    name: splunk
+    name: ${GABI_INSTANCE}-splunk
   type: Opaque
+  stringData:
+    SPLUNK_TOKEN: ${SPLUNK_TOKEN}
+    SPLUNK_ENDPOINT: ${SPLUNK_ENDPOINT}
 - apiVersion: v1
   kind: Service
   metadata:

--- a/openshift/gabi.template.yaml
+++ b/openshift/gabi.template.yaml
@@ -112,9 +112,15 @@ objects:
           - name: SPLUNK_INDEX
             value: ${SPLUNK_INDEX}
           - name: SPLUNK_TOKEN
-            value: ${SPLUNK_TOKEN}
+            valueFrom:
+              secretKeyRef:
+                key: SPLUNK_TOKEN
+                name: splunk
           - name: SPLUNK_ENDPOINT
-            value: ${SPLUNK_ENDPOINT}
+            valueFrom:
+              secretKeyRef:
+                key: SPLUNK_ENDPOINT
+                name: splunk
           - name: DB_DRIVER
             value: ${DB_DRIVER}
           - name: DB_WRITE
@@ -161,6 +167,14 @@ objects:
           configMap:
             optional: true
             name: ${GABI_INSTANCE}
+- apiVersion: v1
+  data:
+    SPLUNK_TOKEN: ${SPLUNK_TOKEN}
+    SPLUNK_ENDPOINT: ${SPLUNK_ENDPOINT}
+  kind: Secret
+  metadata:
+    name: splunk
+  type: Opaque
 - apiVersion: v1
   kind: Service
   metadata:

--- a/openshift/gabi.template.yaml
+++ b/openshift/gabi.template.yaml
@@ -9,35 +9,6 @@ objects:
     name: ${GABI_INSTANCE}
     annotations:
       serviceaccounts.openshift.io/oauth-redirectreference.prometheus: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"${GABI_INSTANCE}"}}'
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: ClusterRole
-  metadata:
-    name: openshift-oauth-delegate
-  rules:
-  - apiGroups:
-    - authentication.k8s.io
-    resources:
-    - tokenreviews
-    verbs:
-    - create
-  - apiGroups:
-    - authorization.k8s.io
-    resources:
-    - subjectaccessreviews
-    verbs:
-    - create
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: ClusterRoleBinding
-  metadata:
-    name: openshift-oauth-delegate-gabi-${NAMESPACE}
-  subjects:
-    - kind: ServiceAccount
-      name: ${GABI_INSTANCE}
-      namespace: ${NAMESPACE}
-  roleRef:
-    kind: ClusterRole
-    name: openshift-oauth-delegate
-    apiGroup: rbac.authorization.k8s.io
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -66,23 +37,25 @@ objects:
             name: http
             protocol: TCP
           readinessProbe:
-            failureThreshold: 3
-            periodSeconds: 10
-            successThreshold: 1
             httpGet:
               path: /oauth/healthz
               port: http
               scheme: HTTPS
+            initialDelaySeconds: 5
             timeoutSeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
           livenessProbe:
-            failureThreshold: 3
-            periodSeconds: 10
-            successThreshold: 1
             httpGet:
               path: /oauth/healthz
               port: http
               scheme: HTTPS
+            initialDelaySeconds: 5
             timeoutSeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
           resources:
             limits:
               cpu: 20m
@@ -109,6 +82,7 @@ objects:
               path: /healthcheck
               port: 8080
               scheme: HTTP
+            initialDelaySeconds: 5
             timeoutSeconds: 1
             failureThreshold: 3
             periodSeconds: 10
@@ -118,6 +92,7 @@ objects:
               path: /healthcheck
               port: 8080
               scheme: HTTP
+            initialDelaySeconds: 5
             timeoutSeconds: 1
             failureThreshold: 3
             periodSeconds: 10
@@ -137,15 +112,9 @@ objects:
           - name: SPLUNK_INDEX
             value: ${SPLUNK_INDEX}
           - name: SPLUNK_TOKEN
-            valueFrom:
-              secretKeyRef:
-                key: Token
-                name: ${SPLUNK_SECRET_NAME}
+            value: ${SPLUNK_TOKEN}
           - name: SPLUNK_ENDPOINT
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: ${SPLUNK_SECRET_NAME}
+            value: ${SPLUNK_ENDPOINT}
           - name: DB_DRIVER
             value: ${DB_DRIVER}
           - name: DB_WRITE
@@ -247,12 +216,14 @@ parameters:
   value: db-creds
 - name: HOST
   value: example.com
-- name: SPLUNK_INDEX
-  value: app-sre
 - name: POD_NAME
   value: gabi-staging
-- name: SPLUNK_SECRET_NAME
-  value: splunk-creds
+- name: SPLUNK_INDEX
+  value: app-sre
+- name: SPLUNK_TOKEN
+  required: true
+- name: SPLUNK_ENDPOINT
+  required: true
 - name: GABI_INSTANCE
   value: gabi-instance
 - name: USERS_FILE_PATH


### PR DESCRIPTION
The template being used up to now was gabi-no-cluster-resources.template.yaml
I copied the content over into this gabi.template.yaml so we get the most recent changes and made the SPLUNK TOKEN and ENDPOINT env var directly as required template params.
Those will be set in app-interface using `secretParameters`

app-interface MR to merge after this one: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/46195

A follow up MR could delete gabi-no-cluster-resources.template.yaml for cleanup.