### PR TITLE
Remove deprecated io/ioutil package

### DIFF
--- a/pkg/audit/audit.go
+++ b/pkg/audit/audit.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"go.uber.org/zap"
@@ -94,7 +94,7 @@ func (d *SplunkAudit) Write(s *SplunkQueryData) (SplunkResponse, error) {
 	}
    	defer resp.Body.Close()
 	
-   	body, err := ioutil.ReadAll(resp.Body)
+   	body, err := io.ReadAll(resp.Body)
    	if err != nil {
 		return  *splunkResp, err
    	}


### PR DESCRIPTION
Since Go **1.16**, the **io/ioutil** package has been deprecated (see: [Go 1.16 Release Notes](https://golang.google.cn/doc/go1.16)). Even though the old package, which currently is more of a proxy package, is still available for backward compatibility, it's _preferable_ to use the affected functions directly from the new packages.

Thus, update current users of the **io/ioutil** package so that each uses its respective new package, either **os** or **io**, and then remove **io/ioutil** altogether.

No change to functionality intended.

Signed-off-by: Krzysztof Wilczyński <kwilczynski@redhat.com>