### PR TITLE
APPSRE-6524: Reduce log creation for the health check endpoint requests

### DIFF
--- a/openshift/gabi.template.yaml
+++ b/openshift/gabi.template.yaml
@@ -107,6 +107,8 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          - name: ENVIRONMENT
+            value: ${ENVIRONMENT}
           - name: NAMESPACE
             value: ${NAMESPACE}
           - name: SPLUNK_INDEX
@@ -222,6 +224,8 @@ objects:
       termination: reencrypt
       insecureEdgeTerminationPolicy: Redirect
 parameters:
+- name: ENVIRONMENT
+  value: development
 - name: NAMESPACE
   value: gabi
 - name: IMAGE_TAG

--- a/pkg/handlers/healthcheck.go
+++ b/pkg/handlers/healthcheck.go
@@ -3,8 +3,6 @@ package handlers
 import (
 	"context"
 	"errors"
-	"fmt"
-	"log"
 	"net/http"
 	"time"
 
@@ -21,10 +19,9 @@ func Healthcheck(env *gabi.Env) http.Handler {
 				func(ctx context.Context) error {
 					err := env.DB.PingContext(ctx)
 					if err != nil {
-						errStr := "failed to connect to database as part of healthcheck ping"
-						logErr := fmt.Errorf(errStr+": %v", err)
-						log.Println(logErr)
-						return errors.New("failed to connect database... see gabi logs for further details")
+						l := "Unable to connect to the database"
+						env.Logger.Errorf("%s: %s", l, err)
+						return errors.New(l)
 					}
 					return nil // healthcheck passed successfully
 				},

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -108,7 +108,7 @@ func TestHealthCheckOkay(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	assert.Contains(t, string(body), "{\"status\":\"OK\"}")
+	assert.Contains(t, string(body), `{"status":"OK"}`)
 }
 
 func TestHealthCheckFail(t *testing.T) {
@@ -135,7 +135,7 @@ func TestHealthCheckFail(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	assert.Contains(t, string(body), "{\"status\":\"Service Unavailable\",\"errors\":{\"database\":\"failed to connect database.")
+	assert.Contains(t, string(body), `{"status":"Service Unavailable","errors":{"database":"Unable to connect to the database"}}`)
 }
 
 func TestWithSplunkWrite(t *testing.T) {
@@ -191,7 +191,7 @@ func TestWithSplunkWrite(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	assert.Contains(t, string(body), "{\"result\":[[\"?column?\"],[\"1\"]],\"error\":\"\"}")
+	assert.Contains(t, string(body), `{"result":[["?column?"],["1"]],"error":""}`)
 }
 
 func setEnv(userfile, dbHost, dbPort, splunkToken, splunkEndpoint string) {


### PR DESCRIPTION
Currently, a single middleware-based handler produces HTTP request access logs. This also covers the health check endpoint, which is contacted every few seconds by the Kubernetes liveness probe, leading to an excessive amount of not-so-useful log entries to be generated - most of which consist of simply "200 OK" responses.

Thus, this change reduces the health check endpoint request log generation only to a non-production environment.

While at it, change the health check handler to use the available Zap logger for consistency with the rest of the code base.

Related: [APPSRE-6524](https://issues.redhat.com/browse/APPSRE-6524)

Signed-off-by: Krzysztof Wilczyński <kwilczynski@redhat.com>