### PR TITLE
APPSRE-7066: Support Base64-encoded value as SQL query and when encoding results

### DIFF
--- a/pkg/audit/splunk.go
+++ b/pkg/audit/splunk.go
@@ -24,7 +24,7 @@ const (
 )
 
 type SplunkAudit struct {
-	SplunkEnv *splunk.SplunkEnv
+	SplunkEnv *splunk.Env
 
 	client *http.Client
 }
@@ -55,7 +55,7 @@ func WithHTTPClient(client *http.Client) Option {
 	}
 }
 
-func NewSplunkAudit(splunk *splunk.SplunkEnv, options ...Option) *SplunkAudit {
+func NewSplunkAudit(splunk *splunk.Env, options ...Option) *SplunkAudit {
 	s := &SplunkAudit{SplunkEnv: splunk}
 
 	s.client = &http.Client{

--- a/pkg/audit/splunk_test.go
+++ b/pkg/audit/splunk_test.go
@@ -22,7 +22,7 @@ func TestNewSplunkAudit(t *testing.T) {
 	cases := []struct {
 		description string
 		given       Option
-		want        *splunk.SplunkEnv
+		want        *splunk.Env
 		option      bool
 	}{
 		{
@@ -30,7 +30,7 @@ func TestNewSplunkAudit(t *testing.T) {
 			func(s *SplunkAudit) {
 				s.SplunkEnv.Index = "test"
 			},
-			&splunk.SplunkEnv{Index: "test"},
+			&splunk.Env{Index: "test"},
 			true,
 		},
 		{
@@ -38,7 +38,7 @@ func TestNewSplunkAudit(t *testing.T) {
 			func(s *SplunkAudit) {
 				// No-op.
 			},
-			&splunk.SplunkEnv{},
+			&splunk.Env{},
 			true,
 		},
 		{
@@ -46,7 +46,7 @@ func TestNewSplunkAudit(t *testing.T) {
 			func(s *SplunkAudit) {
 				// No-op.
 			},
-			&splunk.SplunkEnv{},
+			&splunk.Env{},
 			false,
 		},
 	}
@@ -59,9 +59,9 @@ func TestNewSplunkAudit(t *testing.T) {
 			var actual *SplunkAudit
 
 			if tc.option {
-				actual = NewSplunkAudit(&splunk.SplunkEnv{}, tc.given)
+				actual = NewSplunkAudit(&splunk.Env{}, tc.given)
 			} else {
-				actual = NewSplunkAudit(&splunk.SplunkEnv{})
+				actual = NewSplunkAudit(&splunk.Env{})
 			}
 
 			require.NotNil(t, actual)
@@ -96,7 +96,7 @@ func TestWithHTTPClient(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			t.Parallel()
 
-			actual := NewSplunkAudit(&splunk.SplunkEnv{}, tc.given...)
+			actual := NewSplunkAudit(&splunk.Env{}, tc.given...)
 
 			require.NotNil(t, actual)
 
@@ -141,7 +141,7 @@ func TestSetHTTPClient(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			t.Parallel()
 
-			actual := NewSplunkAudit(&splunk.SplunkEnv{})
+			actual := NewSplunkAudit(&splunk.Env{})
 			tc.given(actual)
 
 			require.NotNil(t, actual)
@@ -165,7 +165,7 @@ func TestSplunkAduitWrite(t *testing.T) {
 		description string
 		given       QueryData
 		headers     func() *http.Header
-		server      func(*httptest.Server) *splunk.SplunkEnv
+		server      func(*httptest.Server) *splunk.Env
 		handler     func(*bytes.Buffer, *http.Header) func(w http.ResponseWriter, r *http.Request)
 		error       bool
 		message     string
@@ -183,8 +183,8 @@ func TestSplunkAduitWrite(t *testing.T) {
 					"User-Agent":      []string{fmt.Sprintf("GABI/%s", version.Version())},
 				}
 			},
-			func(s *httptest.Server) *splunk.SplunkEnv {
-				return &splunk.SplunkEnv{
+			func(s *httptest.Server) *splunk.Env {
+				return &splunk.Env{
 					Endpoint:  s.URL,
 					Token:     "test123",
 					Host:      "test",
@@ -216,8 +216,8 @@ func TestSplunkAduitWrite(t *testing.T) {
 					"User-Agent":      []string{fmt.Sprintf("GABI/%s", version.Version())},
 				}
 			},
-			func(s *httptest.Server) *splunk.SplunkEnv {
-				return &splunk.SplunkEnv{
+			func(s *httptest.Server) *splunk.Env {
+				return &splunk.Env{
 					Endpoint:  s.URL,
 					Token:     "test123",
 					Host:      "test",
@@ -249,8 +249,8 @@ func TestSplunkAduitWrite(t *testing.T) {
 					"User-Agent":      []string{fmt.Sprintf("GABI/%s", version.Version())},
 				}
 			},
-			func(s *httptest.Server) *splunk.SplunkEnv {
-				return &splunk.SplunkEnv{
+			func(s *httptest.Server) *splunk.Env {
+				return &splunk.Env{
 					Endpoint: s.URL,
 				}
 			},
@@ -272,8 +272,8 @@ func TestSplunkAduitWrite(t *testing.T) {
 			func() *http.Header {
 				return &http.Header{}
 			},
-			func(s *httptest.Server) *splunk.SplunkEnv {
-				return &splunk.SplunkEnv{}
+			func(s *httptest.Server) *splunk.Env {
+				return &splunk.Env{}
 			},
 			func(b *bytes.Buffer, h *http.Header) func(w http.ResponseWriter, r *http.Request) {
 				return func(w http.ResponseWriter, r *http.Request) {
@@ -290,8 +290,8 @@ func TestSplunkAduitWrite(t *testing.T) {
 			func() *http.Header {
 				return &http.Header{}
 			},
-			func(s *httptest.Server) *splunk.SplunkEnv {
-				return &splunk.SplunkEnv{
+			func(s *httptest.Server) *splunk.Env {
+				return &splunk.Env{
 					Endpoint: "http://test/%",
 				}
 			},
@@ -310,8 +310,8 @@ func TestSplunkAduitWrite(t *testing.T) {
 			func() *http.Header {
 				return &http.Header{}
 			},
-			func(s *httptest.Server) *splunk.SplunkEnv {
-				return &splunk.SplunkEnv{
+			func(s *httptest.Server) *splunk.Env {
+				return &splunk.Env{
 					Endpoint: "http://test",
 				}
 			},
@@ -336,8 +336,8 @@ func TestSplunkAduitWrite(t *testing.T) {
 					"User-Agent":      []string{fmt.Sprintf("GABI/%s", version.Version())},
 				}
 			},
-			func(s *httptest.Server) *splunk.SplunkEnv {
-				return &splunk.SplunkEnv{
+			func(s *httptest.Server) *splunk.Env {
+				return &splunk.Env{
 					Endpoint: s.URL,
 					Token:    "test123",
 				}
@@ -366,8 +366,8 @@ func TestSplunkAduitWrite(t *testing.T) {
 					"User-Agent":      []string{fmt.Sprintf("GABI/%s", version.Version())},
 				}
 			},
-			func(s *httptest.Server) *splunk.SplunkEnv {
-				return &splunk.SplunkEnv{
+			func(s *httptest.Server) *splunk.Env {
+				return &splunk.Env{
 					Endpoint: s.URL,
 					Token:    "test123",
 				}
@@ -390,8 +390,8 @@ func TestSplunkAduitWrite(t *testing.T) {
 			func() *http.Header {
 				return &http.Header{}
 			},
-			func(s *httptest.Server) *splunk.SplunkEnv {
-				return &splunk.SplunkEnv{}
+			func(s *httptest.Server) *splunk.Env {
+				return &splunk.Env{}
 			},
 			func(b *bytes.Buffer, h *http.Header) func(w http.ResponseWriter, r *http.Request) {
 				return func(w http.ResponseWriter, r *http.Request) {
@@ -414,8 +414,8 @@ func TestSplunkAduitWrite(t *testing.T) {
 					"User-Agent":      []string{fmt.Sprintf("GABI/%s", version.Version())},
 				}
 			},
-			func(s *httptest.Server) *splunk.SplunkEnv {
-				return &splunk.SplunkEnv{
+			func(s *httptest.Server) *splunk.Env {
+				return &splunk.Env{
 					Endpoint:  s.URL,
 					Token:     "test123",
 					Host:      "test",

--- a/pkg/env/db/db.go
+++ b/pkg/env/db/db.go
@@ -9,7 +9,7 @@ import (
 	"github.com/app-sre/gabi/pkg/env"
 )
 
-type DBEnv struct {
+type Env struct {
 	Driver     DriverType
 	Host       string
 	Port       int
@@ -19,14 +19,14 @@ type DBEnv struct {
 	AllowWrite bool
 }
 
-func NewDBEnv() *DBEnv {
-	return &DBEnv{}
+func NewDBEnv() *Env {
+	return &Env{}
 }
 
-func (d *DBEnv) Populate() error {
+func (d *Env) Populate() error {
 	driver := os.Getenv("DB_DRIVER")
 	if driver == "" {
-		return &env.EnvError{Name: "DB_DRIVER"}
+		return &env.Error{Name: "DB_DRIVER"}
 	}
 	d.Driver = DriverType(driver)
 
@@ -36,7 +36,7 @@ func (d *DBEnv) Populate() error {
 
 	host := os.Getenv("DB_HOST")
 	if host == "" {
-		return &env.EnvError{Name: "DB_HOST"}
+		return &env.Error{Name: "DB_HOST"}
 	}
 	d.Host = host
 
@@ -45,26 +45,26 @@ func (d *DBEnv) Populate() error {
 	if portString != "" {
 		port, err := strconv.ParseInt(portString, 10, 0)
 		if err != nil {
-			return &env.EnvTypeError{Name: "DB_PORT"}
+			return &env.TypeError{Name: "DB_PORT"}
 		}
 		d.Port = int(port)
 	}
 
 	username := os.Getenv("DB_USER")
 	if username == "" {
-		return &env.EnvError{Name: "DB_USER"}
+		return &env.Error{Name: "DB_USER"}
 	}
 	d.Username = username
 
 	password := os.Getenv("DB_PASS")
 	if password == "" {
-		return &env.EnvError{Name: "DB_PASS"}
+		return &env.Error{Name: "DB_PASS"}
 	}
 	d.Password = password
 
 	name := os.Getenv("DB_NAME")
 	if name == "" {
-		return &env.EnvError{Name: "DB_NAME"}
+		return &env.Error{Name: "DB_NAME"}
 	}
 	d.Name = name
 
@@ -73,7 +73,7 @@ func (d *DBEnv) Populate() error {
 	if writeString != "" {
 		write, err := strconv.ParseBool(writeString)
 		if err != nil {
-			return &env.EnvTypeError{Name: "DB_WRITE"}
+			return &env.TypeError{Name: "DB_WRITE"}
 		}
 		d.AllowWrite = write
 	}
@@ -86,6 +86,6 @@ func (d *DBEnv) Populate() error {
 	return nil
 }
 
-func (d *DBEnv) ConnectionDSN() string {
+func (d *Env) ConnectionDSN() string {
 	return fmt.Sprintf(d.Driver.Format(), d.Username, d.Password, d.Host, d.Port, d.Name)
 }

--- a/pkg/env/db/db_test.go
+++ b/pkg/env/db/db_test.go
@@ -14,14 +14,14 @@ func TestNewDBEnv(t *testing.T) {
 	actual := NewDBEnv()
 
 	require.NotNil(t, actual)
-	assert.IsType(t, &DBEnv{}, actual)
+	assert.IsType(t, &Env{}, actual)
 }
 
 func TestPopulate(t *testing.T) {
 	cases := []struct {
 		description string
 		given       func()
-		expected    *DBEnv
+		expected    *Env
 		error       bool
 		want        string
 	}{
@@ -36,7 +36,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("DB_NAME", "test")
 				t.Setenv("DB_WRITE", "false")
 			},
-			&DBEnv{
+			&Env{
 				Driver:     "pgx",
 				Host:       "test",
 				Port:       1234,
@@ -52,7 +52,7 @@ func TestPopulate(t *testing.T) {
 			"missing required environment variables",
 			func() {
 			},
-			&DBEnv{},
+			&Env{},
 			true,
 			`unable to access environment variable: DB_DRIVER`,
 		},
@@ -61,7 +61,7 @@ func TestPopulate(t *testing.T) {
 			func() {
 				t.Setenv("DB_DRIVER", "")
 			},
-			&DBEnv{},
+			&Env{},
 			true,
 			`unable to access environment variable: DB_DRIVER`,
 		},
@@ -70,7 +70,7 @@ func TestPopulate(t *testing.T) {
 			func() {
 				t.Setenv("DB_DRIVER", "pgx")
 			},
-			&DBEnv{Driver: "pgx"},
+			&Env{Driver: "pgx"},
 			true,
 			`unable to access environment variable: DB_HOST`,
 		},
@@ -81,7 +81,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("DB_HOST", "test")
 				t.Setenv("DB_PORT", "1234")
 			},
-			&DBEnv{Driver: "pgx", Host: "test", Port: 1234},
+			&Env{Driver: "pgx", Host: "test", Port: 1234},
 			true,
 			`unable to access environment variable: DB_USER`,
 		},
@@ -93,7 +93,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("DB_PORT", "1234")
 				t.Setenv("DB_USER", "test")
 			},
-			&DBEnv{Driver: "pgx", Host: "test", Port: 1234, Username: "test"},
+			&Env{Driver: "pgx", Host: "test", Port: 1234, Username: "test"},
 			true,
 			`unable to access environment variable: DB_PASS`,
 		},
@@ -106,7 +106,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("DB_USER", "test")
 				t.Setenv("DB_PASS", "test123")
 			},
-			&DBEnv{Driver: "pgx", Host: "test", Port: 1234, Username: "test", Password: "test123"},
+			&Env{Driver: "pgx", Host: "test", Port: 1234, Username: "test", Password: "test123"},
 			true,
 			`unable to access environment variable: DB_NAME`,
 		},
@@ -119,7 +119,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("DB_PASS", "test123")
 				t.Setenv("DB_NAME", "test")
 			},
-			&DBEnv{
+			&Env{
 				Driver:     "pgx",
 				Host:       "test",
 				Port:       5432,
@@ -140,7 +140,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("DB_PASS", "test123")
 				t.Setenv("DB_NAME", "test")
 			},
-			&DBEnv{
+			&Env{
 				Driver:     "postgres",
 				Host:       "test",
 				Port:       5432,
@@ -157,7 +157,7 @@ func TestPopulate(t *testing.T) {
 			func() {
 				t.Setenv("DB_DRIVER", "test")
 			},
-			&DBEnv{Driver: "test", Host: "", Port: 0, Username: "", Password: "", Name: "", AllowWrite: false},
+			&Env{Driver: "test", Host: "", Port: 0, Username: "", Password: "", Name: "", AllowWrite: false},
 			true,
 			`unable to use driver type: test`,
 		},
@@ -171,7 +171,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("DB_NAME", "test")
 				t.Setenv("DB_WRITE", "true")
 			},
-			&DBEnv{
+			&Env{
 				Driver:     "pgx",
 				Host:       "test",
 				Port:       5432,
@@ -190,7 +190,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("DB_HOST", "test")
 				t.Setenv("DB_PORT", "test")
 			},
-			&DBEnv{Driver: "pgx", Host: "test", Port: 5432, Username: "", Password: "", Name: "", AllowWrite: false},
+			&Env{Driver: "pgx", Host: "test", Port: 5432, Username: "", Password: "", Name: "", AllowWrite: false},
 			true,
 			`unable to convert environment variable: DB_PORT`,
 		},
@@ -204,7 +204,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("DB_NAME", "test")
 				t.Setenv("DB_WRITE", "-1")
 			},
-			&DBEnv{Driver: "pgx", Host: "test", Port: 5432, Username: "test", Password: "test123", Name: "test", AllowWrite: false},
+			&Env{Driver: "pgx", Host: "test", Port: 5432, Username: "test", Password: "test123", Name: "test", AllowWrite: false},
 			true,
 			`unable to convert environment variable: DB_WRITE`,
 		},
@@ -219,7 +219,7 @@ func TestPopulate(t *testing.T) {
 
 			tc.given()
 
-			actual := &DBEnv{}
+			actual := &Env{}
 			err := actual.Populate()
 
 			if tc.error {
@@ -299,7 +299,7 @@ func TestConnectionDSN(t *testing.T) {
 
 			tc.given()
 
-			expected := &DBEnv{}
+			expected := &Env{}
 			err := expected.Populate()
 
 			require.NoError(t, err)

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -2,18 +2,18 @@ package env
 
 import "fmt"
 
-type EnvError struct {
+type Error struct {
 	Name string
 }
 
-func (e *EnvError) Error() string {
+func (e *Error) Error() string {
 	return fmt.Sprintf("unable to access environment variable: %s", e.Name)
 }
 
-type EnvTypeError struct {
+type TypeError struct {
 	Name string
 }
 
-func (e *EnvTypeError) Error() string {
+func (e *TypeError) Error() string {
 	return fmt.Sprintf("unable to convert environment variable: %s", e.Name)
 }

--- a/pkg/env/splunk/splunk.go
+++ b/pkg/env/splunk/splunk.go
@@ -6,7 +6,7 @@ import (
 	"github.com/app-sre/gabi/pkg/env"
 )
 
-type SplunkEnv struct {
+type Env struct {
 	Index     string
 	Endpoint  string
 	Token     string
@@ -15,44 +15,44 @@ type SplunkEnv struct {
 	Pod       string
 }
 
-func NewSplunkEnv() *SplunkEnv {
-	return &SplunkEnv{}
+func NewSplunkEnv() *Env {
+	return &Env{}
 }
 
-func (s *SplunkEnv) Populate() error {
+func (s *Env) Populate() error {
 	index := os.Getenv("SPLUNK_INDEX")
 	if index == "" {
-		return &env.EnvError{Name: "SPLUNK_INDEX"}
+		return &env.Error{Name: "SPLUNK_INDEX"}
 	}
 	s.Index = index
 
 	endpoint := os.Getenv("SPLUNK_ENDPOINT")
 	if endpoint == "" {
-		return &env.EnvError{Name: "SPLUNK_ENDPOINT"}
+		return &env.Error{Name: "SPLUNK_ENDPOINT"}
 	}
 	s.Endpoint = endpoint
 
 	token := os.Getenv("SPLUNK_TOKEN")
 	if token == "" {
-		return &env.EnvError{Name: "SPLUNK_TOKEN"}
+		return &env.Error{Name: "SPLUNK_TOKEN"}
 	}
 	s.Token = token
 
 	host := os.Getenv("HOST")
 	if host == "" {
-		return &env.EnvError{Name: "HOST"}
+		return &env.Error{Name: "HOST"}
 	}
 	s.Host = host
 
 	namespace := os.Getenv("NAMESPACE")
 	if namespace == "" {
-		return &env.EnvError{Name: "NAMESPACE"}
+		return &env.Error{Name: "NAMESPACE"}
 	}
 	s.Namespace = namespace
 
 	pod := os.Getenv("POD_NAME")
 	if pod == "" {
-		return &env.EnvError{Name: "POD_NAME"}
+		return &env.Error{Name: "POD_NAME"}
 	}
 	s.Pod = pod
 

--- a/pkg/env/splunk/splunk_test.go
+++ b/pkg/env/splunk/splunk_test.go
@@ -14,14 +14,14 @@ func TestNewSplunkEnv(t *testing.T) {
 	actual := NewSplunkEnv()
 
 	require.NotNil(t, actual)
-	assert.IsType(t, &SplunkEnv{}, actual)
+	assert.IsType(t, &Env{}, actual)
 }
 
 func TestPopulate(t *testing.T) {
 	cases := []struct {
 		description string
 		given       func()
-		expected    *SplunkEnv
+		expected    *Env
 		error       bool
 		want        string
 	}{
@@ -35,7 +35,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("NAMESPACE", "test")
 				t.Setenv("POD_NAME", "test")
 			},
-			&SplunkEnv{Index: "test", Endpoint: "test", Token: "test123", Host: "test", Namespace: "test", Pod: "test"},
+			&Env{Index: "test", Endpoint: "test", Token: "test123", Host: "test", Namespace: "test", Pod: "test"},
 			false,
 			``,
 		},
@@ -43,7 +43,7 @@ func TestPopulate(t *testing.T) {
 			"missing required SPLUNK_INDEX environment variable",
 			func() {
 			},
-			&SplunkEnv{},
+			&Env{},
 			true,
 			`unable to access environment variable: SPLUNK_INDEX`,
 		},
@@ -52,7 +52,7 @@ func TestPopulate(t *testing.T) {
 			func() {
 				t.Setenv("SPLUNK_INDEX", "")
 			},
-			&SplunkEnv{},
+			&Env{},
 			true,
 			`unable to access environment variable: SPLUNK_INDEX`,
 		},
@@ -61,7 +61,7 @@ func TestPopulate(t *testing.T) {
 			func() {
 				t.Setenv("SPLUNK_INDEX", "test")
 			},
-			&SplunkEnv{Index: "test"},
+			&Env{Index: "test"},
 			true,
 			`unable to access environment variable: SPLUNK_ENDPOINT`,
 		},
@@ -71,7 +71,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("SPLUNK_INDEX", "test")
 				t.Setenv("SPLUNK_ENDPOINT", "test")
 			},
-			&SplunkEnv{Index: "test", Endpoint: "test", Token: "", Host: "", Namespace: "", Pod: ""},
+			&Env{Index: "test", Endpoint: "test", Token: "", Host: "", Namespace: "", Pod: ""},
 			true,
 			`unable to access environment variable: SPLUNK_TOKEN`,
 		},
@@ -82,7 +82,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("SPLUNK_ENDPOINT", "test")
 				t.Setenv("SPLUNK_TOKEN", "test123")
 			},
-			&SplunkEnv{Index: "test", Endpoint: "test", Token: "test123", Host: "", Namespace: "", Pod: ""},
+			&Env{Index: "test", Endpoint: "test", Token: "test123", Host: "", Namespace: "", Pod: ""},
 			true,
 			`unable to access environment variable: HOST`,
 		},
@@ -94,7 +94,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("SPLUNK_TOKEN", "test123")
 				t.Setenv("HOST", "test")
 			},
-			&SplunkEnv{Index: "test", Endpoint: "test", Token: "test123", Host: "test", Namespace: "", Pod: ""},
+			&Env{Index: "test", Endpoint: "test", Token: "test123", Host: "test", Namespace: "", Pod: ""},
 			true,
 			`unable to access environment variable: NAMESPACE`,
 		},
@@ -107,7 +107,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("HOST", "test")
 				t.Setenv("NAMESPACE", "test")
 			},
-			&SplunkEnv{Index: "test", Endpoint: "test", Token: "test123", Host: "test", Namespace: "test", Pod: ""},
+			&Env{Index: "test", Endpoint: "test", Token: "test123", Host: "test", Namespace: "test", Pod: ""},
 			true,
 			`unable to access environment variable: POD_NAME`,
 		},
@@ -122,7 +122,7 @@ func TestPopulate(t *testing.T) {
 
 			tc.given()
 
-			actual := &SplunkEnv{}
+			actual := &Env{}
 			err := actual.Populate()
 
 			if tc.error {

--- a/pkg/env/user/user.go
+++ b/pkg/env/user/user.go
@@ -14,16 +14,16 @@ import (
 
 const ExpiryDateLayout = "2006-01-02"
 
-type UserEnv struct {
+type Env struct {
 	Expiration time.Time `json:"expiration"`
 	Users      []string  `json:"users"`
 }
 
-func NewUserEnv() *UserEnv {
-	return &UserEnv{}
+func NewUserEnv() *Env {
+	return &Env{}
 }
 
-func (u *UserEnv) Populate() error {
+func (u *Env) Populate() error {
 	if path := os.Getenv("USERS_FILE_PATH"); path != "" {
 		file, err := os.Open(path)
 		if err != nil {
@@ -61,7 +61,7 @@ func (u *UserEnv) Populate() error {
 		u.Expiration = t
 	}
 	if u.Expiration == (time.Time{}) {
-		return &env.EnvError{Name: "EXPIRATION_DATE"}
+		return &env.Error{Name: "EXPIRATION_DATE"}
 	}
 
 	if users := os.Getenv("AUTHORIZED_USERS"); users != "" {
@@ -79,19 +79,19 @@ func (u *UserEnv) Populate() error {
 	return nil
 }
 
-func (u *UserEnv) IsDeprecated() bool {
+func (u *Env) IsDeprecated() bool {
 	return u.Expiration == (time.Time{})
 }
 
-func (u *UserEnv) IsExpired() bool {
+func (u *Env) IsExpired() bool {
 	if u.IsDeprecated() {
 		return len(u.Users) == 0
 	}
 	return u.Expiration.Before(time.Now())
 }
 
-func (u *UserEnv) MarshalJSON() ([]byte, error) {
-	type alias UserEnv
+func (u *Env) MarshalJSON() ([]byte, error) {
+	type alias Env
 
 	aux := &struct {
 		*alias
@@ -110,7 +110,7 @@ func (u *UserEnv) MarshalJSON() ([]byte, error) {
 	return json, nil
 }
 
-func (u *UserEnv) UnmarshalJSON(b []byte) error {
+func (u *Env) UnmarshalJSON(b []byte) error {
 	var raw map[string]any
 
 	if err := json.Unmarshal(b, &raw); err != nil {

--- a/pkg/env/user/user_test.go
+++ b/pkg/env/user/user_test.go
@@ -15,14 +15,14 @@ func TestNewUserEnv(t *testing.T) {
 	actual := NewUserEnv()
 
 	require.NotNil(t, actual)
-	assert.IsType(t, &UserEnv{}, actual)
+	assert.IsType(t, &Env{}, actual)
 }
 
 func TestPopulate(t *testing.T) {
 	cases := []struct {
 		description string
 		given       func() string
-		expected    *UserEnv
+		expected    *Env
 		error       bool
 		want        string
 	}{
@@ -33,7 +33,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("AUTHORIZED_USERS", "test")
 				return ""
 			},
-			&UserEnv{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), Users: []string{"test"}},
+			&Env{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), Users: []string{"test"}},
 			false,
 			``,
 		},
@@ -42,7 +42,7 @@ func TestPopulate(t *testing.T) {
 			func() string {
 				return ""
 			},
-			&UserEnv{},
+			&Env{},
 			true,
 			`unable to access environment variable: EXPIRATION_DATE`,
 		},
@@ -52,7 +52,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("EXPIRATION_DATE", "test")
 				return ""
 			},
-			&UserEnv{},
+			&Env{},
 			true,
 			`unable to parse expiration date`,
 		},
@@ -62,7 +62,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("EXPIRATION_DATE", "2023-01-01")
 				return ""
 			},
-			&UserEnv{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)},
+			&Env{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)},
 			false,
 			``,
 		},
@@ -73,7 +73,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("AUTHORIZED_USERS", "")
 				return ""
 			},
-			&UserEnv{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)},
+			&Env{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)},
 			false,
 			``,
 		},
@@ -91,7 +91,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("CONFIG_FILE_PATH", file.Name())
 				return file.Name()
 			},
-			&UserEnv{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)},
+			&Env{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)},
 			false,
 			``,
 		},
@@ -109,7 +109,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("CONFIG_FILE_PATH", file.Name())
 				return file.Name()
 			},
-			&UserEnv{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), Users: []string{"test"}},
+			&Env{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), Users: []string{"test"}},
 			false,
 			``,
 		},
@@ -128,7 +128,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("AUTHORIZED_USERS", "test2")
 				return file.Name()
 			},
-			&UserEnv{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), Users: []string{"test2"}},
+			&Env{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), Users: []string{"test2"}},
 			false,
 			``,
 		},
@@ -146,7 +146,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("USERS_FILE_PATH", file.Name())
 				return file.Name()
 			},
-			&UserEnv{Users: []string{"test"}},
+			&Env{Users: []string{"test"}},
 			false,
 			``,
 		},
@@ -160,7 +160,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("USERS_FILE_PATH", file.Name())
 				return file.Name()
 			},
-			&UserEnv{},
+			&Env{},
 			false,
 			``,
 		},
@@ -170,7 +170,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("CONFIG_FILE_PATH", "test")
 				return ""
 			},
-			&UserEnv{},
+			&Env{},
 			true,
 			`unable to read users file: open test`,
 		},
@@ -180,7 +180,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("USERS_FILE_PATH", "test")
 				return ""
 			},
-			&UserEnv{},
+			&Env{},
 			true,
 			`unable to read users file`,
 		},
@@ -198,7 +198,7 @@ func TestPopulate(t *testing.T) {
 				t.Setenv("CONFIG_FILE_PATH", file.Name())
 				return file.Name()
 			},
-			&UserEnv{},
+			&Env{},
 			true,
 			`unable to unmarshal users file`,
 		},
@@ -213,7 +213,7 @@ func TestPopulate(t *testing.T) {
 				os.Remove(file)
 			})
 
-			actual := &UserEnv{}
+			actual := &Env{}
 			err := actual.Populate()
 
 			if tc.error {
@@ -233,22 +233,22 @@ func TestIsDeprecated(t *testing.T) {
 
 	cases := []struct {
 		description string
-		given       UserEnv
+		given       Env
 		expected    bool
 	}{
 		{
 			"not deprecated with expiration date set",
-			UserEnv{Expiration: time.Now()},
+			Env{Expiration: time.Now()},
 			false,
 		},
 		{
 			"deprecated with default expiration date value set",
-			UserEnv{Expiration: time.Time{}},
+			Env{Expiration: time.Time{}},
 			true,
 		},
 		{
 			"deprecated with nothing set",
-			UserEnv{},
+			Env{},
 			true,
 		},
 	}
@@ -270,22 +270,22 @@ func TestIsExpired(t *testing.T) {
 
 	cases := []struct {
 		description string
-		given       UserEnv
+		given       Env
 		expected    bool
 	}{
 		{
 			"before expiration date",
-			UserEnv{Expiration: time.Now().AddDate(0, 0, 1)},
+			Env{Expiration: time.Now().AddDate(0, 0, 1)},
 			false,
 		},
 		{
 			"past expiration date",
-			UserEnv{Expiration: time.Now().AddDate(0, 0, -1)},
+			Env{Expiration: time.Now().AddDate(0, 0, -1)},
 			true,
 		},
 		{
 			"invalid expiration date",
-			UserEnv{},
+			Env{},
 			true,
 		},
 	}
@@ -307,52 +307,52 @@ func TestMarshalJSON(t *testing.T) {
 
 	cases := []struct {
 		description string
-		given       UserEnv
+		given       Env
 		expected    string
 	}{
 		{
 			"users and expiration date",
-			UserEnv{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), Users: []string{"test"}},
+			Env{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), Users: []string{"test"}},
 			`{"users":["test"],"expiration":"2023-01-01"}`,
 		},
 		{
 			"no users and no expiration date",
-			UserEnv{},
+			Env{},
 			`{"users":[],"expiration":"0001-01-01"}`,
 		},
 		{
 			"empty users and empty expiration date",
-			UserEnv{Users: []string{}, Expiration: time.Time{}},
+			Env{Users: []string{}, Expiration: time.Time{}},
 			`{"users":[],"expiration":"0001-01-01"}`,
 		},
 		{
 			"empty users and no expiration date",
-			UserEnv{Users: []string{}},
+			Env{Users: []string{}},
 			`{"users":[],"expiration":"0001-01-01"}`,
 		},
 		{
 			"users and no expiration date",
-			UserEnv{Users: []string{"test"}},
+			Env{Users: []string{"test"}},
 			`{"users":["test"],"expiration":"0001-01-01"}`,
 		},
 		{
 			"no users and expiration date",
-			UserEnv{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)},
+			Env{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)},
 			`{"users":[],"expiration":"2023-01-01"}`,
 		},
 		{
 			"empty users and expiration date",
-			UserEnv{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), Users: []string{}},
+			Env{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), Users: []string{}},
 			`{"users":[],"expiration":"2023-01-01"}`,
 		},
 		{
 			"users and empty expiration date",
-			UserEnv{Users: []string{"test"}, Expiration: time.Time{}},
+			Env{Users: []string{"test"}, Expiration: time.Time{}},
 			`{"users":["test"],"expiration":"0001-01-01"}`,
 		},
 		{
 			"no users and empty expiration date",
-			UserEnv{Expiration: time.Time{}},
+			Env{Expiration: time.Time{}},
 			`{"users":[],"expiration":"0001-01-01"}`,
 		},
 	}
@@ -376,91 +376,91 @@ func TestUnmarshalJSON(t *testing.T) {
 	cases := []struct {
 		description string
 		given       string
-		expected    UserEnv
+		expected    Env
 		error       bool
 		want        string
 	}{
 		{
 			"valid JSON with users and expiration date",
 			`{"users":["test"],"expiration":"2023-01-01"}`,
-			UserEnv{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), Users: []string{"test"}},
+			Env{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), Users: []string{"test"}},
 			false,
 			``,
 		},
 		{
 			"valid JSON with users and expiration date set to null",
 			`{"users":null,"expiration":null}`,
-			UserEnv{},
+			Env{},
 			true,
 			`unable to parse expiration date`,
 		},
 		{
 			"valid JSON with users and expiration set to empty values",
 			`{"users":[],"expiration":""}`,
-			UserEnv{},
+			Env{},
 			true,
 			`unable to parse expiration date`,
 		},
 		{
 			"valid JSON with users set to null without expiration date",
 			`{"users":null}`,
-			UserEnv{},
+			Env{},
 			true,
 			`unable to find expiration date`,
 		},
 		{
 			"valid JSON with users set to empty value without expiration date",
 			`{"users":[]}`,
-			UserEnv{},
+			Env{},
 			true,
 			`unable to find expiration date`,
 		},
 		{
 			"valid JSON with user set to invalid value",
 			`{"users":["test", -1], "expiration": "2023-01-01"}`,
-			UserEnv{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), Users: []string{"test"}},
+			Env{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), Users: []string{"test"}},
 			true,
 			`unable to parse user`,
 		},
 		{
 			"valid JSON without users with expiration date",
 			`{"expiration":"2023-01-01"}`,
-			UserEnv{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)},
+			Env{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)},
 			true,
 			`unable to find users list`,
 		},
 		{
 			"valid JSON without users with expiration date set to null",
 			`{"expiration":null}`,
-			UserEnv{},
+			Env{},
 			true,
 			`unable to parse expiration date`,
 		},
 		{
 			"valid JSON with users set to null with expiration date",
 			`{"users":null,"expiration":"2023-01-01"}`,
-			UserEnv{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)},
+			Env{Expiration: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)},
 			true,
 			`unable to parse users list`,
 		},
 		{
 			"invalid empty string with nothing set",
 			``,
-			UserEnv{},
+			Env{},
 			true,
 			`unable to unmarshal user file`,
 		},
 		{
 			"invalid empty JSON object with nothing set",
 			`{}`,
-			UserEnv{},
+			Env{},
 			true,
 			`unable to find expiration date`,
 		},
 		{
 			"invalid JSON",
 			`{"users:[], "expiration": "2023-01-01"}`,
-			UserEnv{},
+			Env{},
 			true,
 			`unable to unmarshal user file`,
 		},
@@ -471,7 +471,7 @@ func TestUnmarshalJSON(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			t.Parallel()
 
-			results := UserEnv{}
+			results := Env{}
 			err := results.UnmarshalJSON([]byte(tc.given))
 
 			if tc.error {

--- a/pkg/gabi.go
+++ b/pkg/gabi.go
@@ -2,6 +2,7 @@ package gabi
 
 import (
 	"database/sql"
+	"encoding/base64"
 	"os"
 
 	"github.com/app-sre/gabi/pkg/audit"
@@ -10,13 +11,14 @@ import (
 	"go.uber.org/zap"
 )
 
-type Env struct {
+type Config struct {
 	DB          *sql.DB
-	DBEnv       *db.DBEnv
-	UserEnv     *user.UserEnv
-	LoggerAudit *audit.LoggerAudit
-	SplunkAudit *audit.SplunkAudit
+	DBEnv       *db.Env
+	UserEnv     *user.Env
+	LoggerAudit audit.Audit
+	SplunkAudit audit.Audit
 	Logger      *zap.SugaredLogger
+	Encoder     *base64.Encoding
 }
 
 func Production() bool {

--- a/pkg/handlers/healthcheck.go
+++ b/pkg/handlers/healthcheck.go
@@ -13,16 +13,16 @@ import (
 
 const healthcheckTimeout = 5 * time.Second
 
-func Healthcheck(env *gabi.Env) http.Handler {
+func Healthcheck(cfg *gabi.Config) http.Handler {
 	return healthcheck.Handler(
 		healthcheck.WithTimeout(healthcheckTimeout),
 		healthcheck.WithChecker(
 			"database", healthcheck.CheckerFunc(
 				func(ctx context.Context) error {
-					err := env.DB.PingContext(ctx)
+					err := cfg.DB.PingContext(ctx)
 					if err != nil {
 						l := "Unable to connect to the database"
-						env.Logger.Errorf("%s: %s", l, err)
+						cfg.Logger.Errorf("%s: %s", l, err)
 						return errors.New(l)
 					}
 					return nil

--- a/pkg/handlers/healthcheck_test.go
+++ b/pkg/handlers/healthcheck_test.go
@@ -59,7 +59,7 @@ func TestHealthcheck(t *testing.T) {
 
 			tc.given(mock)
 
-			expected := &gabi.Env{DB: db, Logger: logger}
+			expected := &gabi.Config{DB: db, Logger: logger}
 			Healthcheck(expected).ServeHTTP(w, r)
 
 			actual := w.Result()

--- a/pkg/middleware/authorization.go
+++ b/pkg/middleware/authorization.go
@@ -8,7 +8,7 @@ import (
 	gabi "github.com/app-sre/gabi/pkg"
 )
 
-func Authorization(env *gabi.Env) Middleware {
+func Authorization(cfg *gabi.Config) Middleware {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
@@ -20,19 +20,19 @@ func Authorization(env *gabi.Env) Middleware {
 				return
 			}
 
-			if len(env.UserEnv.Users) == 0 {
+			if len(cfg.UserEnv.Users) == 0 {
 				http.Error(w, "Request cannot be authorized", http.StatusUnauthorized)
 				return
 			}
-			for _, u := range env.UserEnv.Users {
+			for _, u := range cfg.UserEnv.Users {
 				if user == u {
-					ctx = context.WithValue(ctx, contextUserKey, u)
+					ctx = context.WithValue(ctx, ContextKeyUser, u)
 					h.ServeHTTP(w, r.WithContext(ctx))
 					return
 				}
 			}
 			l := "User does not have required permissions"
-			env.Logger.Errorf("%s: %s", l, user)
+			cfg.Logger.Errorf("%s: %s", l, user)
 			http.Error(w, l, http.StatusForbidden)
 		})
 	}

--- a/pkg/middleware/authorization_test.go
+++ b/pkg/middleware/authorization_test.go
@@ -18,7 +18,7 @@ func TestAuthorization(t *testing.T) {
 
 	cases := []struct {
 		description string
-		given       *user.UserEnv
+		given       *user.Env
 		headers     func(*http.Request)
 		code        int
 		body        string
@@ -26,7 +26,7 @@ func TestAuthorization(t *testing.T) {
 	}{
 		{
 			"no users set with valid header",
-			&user.UserEnv{},
+			&user.Env{},
 			func(r *http.Request) {
 				r.Header.Set("X-Forwarded-User", "test")
 			},
@@ -36,7 +36,7 @@ func TestAuthorization(t *testing.T) {
 		},
 		{
 			"empty users lists with valid header",
-			&user.UserEnv{Users: []string{}},
+			&user.Env{Users: []string{}},
 			func(r *http.Request) {
 				r.Header.Set("X-Forwarded-User", "test")
 			},
@@ -46,7 +46,7 @@ func TestAuthorization(t *testing.T) {
 		},
 		{
 			"empty users lists with invalid header",
-			&user.UserEnv{Users: []string{}},
+			&user.Env{Users: []string{}},
 			func(r *http.Request) {
 				r.Header.Set("X-Forwarded-For", "test")
 			},
@@ -56,7 +56,7 @@ func TestAuthorization(t *testing.T) {
 		},
 		{
 			"no users set without required header",
-			&user.UserEnv{},
+			&user.Env{},
 			func(r *http.Request) {
 				// No-op.
 			},
@@ -66,7 +66,7 @@ func TestAuthorization(t *testing.T) {
 		},
 		{
 			"users set without required header",
-			&user.UserEnv{Users: []string{"test"}},
+			&user.Env{Users: []string{"test"}},
 			func(r *http.Request) {
 				// No-op.
 			},
@@ -76,7 +76,7 @@ func TestAuthorization(t *testing.T) {
 		},
 		{
 			"users set with required header value set to invalid user",
-			&user.UserEnv{Users: []string{"test"}},
+			&user.Env{Users: []string{"test"}},
 			func(r *http.Request) {
 				r.Header.Set("X-Forwarded-User", "test2")
 			},
@@ -86,7 +86,7 @@ func TestAuthorization(t *testing.T) {
 		},
 		{
 			"users set with required header value set to valid user",
-			&user.UserEnv{Users: []string{"test"}},
+			&user.Env{Users: []string{"test"}},
 			func(r *http.Request) {
 				r.Header.Set("X-Forwarded-User", "test")
 			},
@@ -113,9 +113,9 @@ func TestAuthorization(t *testing.T) {
 
 			tc.headers(r)
 
-			expected := &gabi.Env{Logger: logger, UserEnv: tc.given}
+			expected := &gabi.Config{Logger: logger, UserEnv: tc.given}
 			Authorization(expected)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				s, ok := r.Context().Value(contextUserKey).(string)
+				s, ok := r.Context().Value(ContextKeyUser).(string)
 				if !ok {
 					t.Fatal("invalid context")
 				}

--- a/pkg/middleware/expiration.go
+++ b/pkg/middleware/expiration.go
@@ -7,13 +7,13 @@ import (
 	"github.com/app-sre/gabi/pkg/env/user"
 )
 
-func Expiration(env *gabi.Env) Middleware {
+func Expiration(cfg *gabi.Config) Middleware {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if env.UserEnv.IsExpired() {
+			if cfg.UserEnv.IsExpired() {
 				l := "The service instance has expired"
-				env.Logger.Errorf("%s (expiration date: %s)", l,
-					env.UserEnv.Expiration.Format(user.ExpiryDateLayout),
+				cfg.Logger.Errorf("%s (expiration date: %s)", l,
+					cfg.UserEnv.Expiration.Format(user.ExpiryDateLayout),
 				)
 				http.Error(w, l, http.StatusServiceUnavailable)
 				return

--- a/pkg/middleware/expiration_test.go
+++ b/pkg/middleware/expiration_test.go
@@ -19,25 +19,25 @@ func TestExpiration(t *testing.T) {
 
 	cases := []struct {
 		description string
-		given       *user.UserEnv
+		given       *user.Env
 		code        int
 		body        string
 	}{
 		{
 			"instance has not expired",
-			&user.UserEnv{Expiration: time.Now().AddDate(0, 0, 1)},
+			&user.Env{Expiration: time.Now().AddDate(0, 0, 1)},
 			200,
 			``,
 		},
 		{
 			"instance has expired",
-			&user.UserEnv{Expiration: time.Now().AddDate(0, 0, -1)},
+			&user.Env{Expiration: time.Now().AddDate(0, 0, -1)},
 			503,
 			`The service instance has expired`,
 		},
 		{
 			"invalid instance without expiration date",
-			&user.UserEnv{},
+			&user.Env{},
 			503,
 			`The service instance has expired`,
 		},
@@ -57,7 +57,7 @@ func TestExpiration(t *testing.T) {
 
 			logger := test.DummyLogger(io.Discard).Sugar()
 
-			expected := &gabi.Env{Logger: logger, UserEnv: tc.given}
+			expected := &gabi.Config{Logger: logger, UserEnv: tc.given}
 			Expiration(expected)(dummyHandler).ServeHTTP(w, r)
 
 			actual := w.Result()

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -7,9 +7,13 @@ import (
 type ctxKey string
 
 const (
-	contextUserKey      ctxKey = "user"
-	contentLengthHeader string = "Content-Length"
-	forwardedUserHeader string = "X-Forwarded-User"
+	ContextKeyUser  ctxKey = "user"
+	ContextKeyQuery ctxKey = "query"
+)
+
+const (
+	contentLengthHeader = "Content-Length"
+	forwardedUserHeader = "X-Forwarded-User"
 )
 
 type Middleware func(http.Handler) http.Handler

--- a/pkg/middleware/recovery.go
+++ b/pkg/middleware/recovery.go
@@ -7,7 +7,7 @@ import (
 	gabi "github.com/app-sre/gabi/pkg"
 )
 
-func Recovery(env *gabi.Env) Middleware {
+func Recovery(cfg *gabi.Config) Middleware {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			defer func() {
@@ -17,7 +17,7 @@ func Recovery(env *gabi.Env) Middleware {
 						panic(err)
 					}
 
-					env.Logger.Errorf("Recovered from an error: %s", r)
+					cfg.Logger.Errorf("Recovered from an error: %s", r)
 					http.Error(w, "An internal error has occurred", http.StatusInternalServerError)
 				}
 			}()

--- a/pkg/middleware/recovery_test.go
+++ b/pkg/middleware/recovery_test.go
@@ -65,7 +65,7 @@ func TestRecovery(t *testing.T) {
 
 			logger := test.DummyLogger(&output).Sugar()
 
-			expected := &gabi.Env{Logger: logger}
+			expected := &gabi.Config{Logger: logger}
 			Recovery(expected)(tc.given).ServeHTTP(w, r)
 
 			actual := w.Result()

--- a/test/helper_test.go
+++ b/test/helper_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/orlangure/gnomock"
 	"github.com/orlangure/gnomock/preset/postgres"
 	"github.com/orlangure/gnomock/preset/splunk"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func dummyHTTPClient() http.Client {
@@ -32,7 +32,7 @@ func dummyHTTPClient() http.Client {
 }
 
 func createConfigurationFile(t *testing.T, expiration time.Time, users []string) string {
-	usere := &user.UserEnv{
+	usere := &user.Env{
 		Expiration: expiration,
 		Users:      users,
 	}
@@ -97,7 +97,7 @@ func startPostgres(t *testing.T) *gnomock.Container {
 	psql, err := gnomock.StartCustom("quay.io/app-sre/postgres:12.5", p.Ports(),
 		options...,
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	t.Cleanup(func() { _ = gnomock.Stop(psql) })
 
@@ -117,7 +117,7 @@ func startSplunk(t *testing.T, password string) *gnomock.Container {
 	splunk, err := gnomock.StartCustom("quay.io/app-sre/splunk:latest", s.Ports(),
 		options...,
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	t.Cleanup(func() { _ = gnomock.Stop(splunk) })
 


### PR DESCRIPTION
Currently, there isn't a convenient way to pass complex data, either in the request (SQL statements) or in the response (columns and rows; more so rows), especially when either the query or results include one or more characters that the JSON standard otherwise considers reserved.

This often hinders the end-user ability to use the service, especially if the data in the database is stored in a format that would infringe on the limitations JSON use can pose - this might include rich plaintext data or even JSON document (such will require elaborate escaping and quoting) that has been stored in the database, or when the JSONB is used for a column where the results are then finally rendered as JSON document.

Thus, this change adds Base64 support for decoding a query (SQL statement) from the request and encoding results (rows returned following query execution).  The service user will have the option to have a different representation than the plaintext form and alleviate some of the limitations imposed on the end-user when the data exchange employs JSON with its known limitations. This support can be enabled and/or disabled on-demand using query parameters.

The Base64 standard was chosen given its widespread industry adoption (e.g., Kubernetes secrets, etc.), ease of implementation, and availability in a given language standard library.

While at it, rename internal types to drop surplus prefixes or suffixes fro them.

Related: [APPSRE-7066](https://issues.redhat.com/browse/APPSRE-7066)

Signed-off-by: Krzysztof Wilczyński <kwilczynski@redhat.com>