### PR TITLE
Update error messages to better relect which parts had failed

### DIFF
--- a/pkg/handlers/query.go
+++ b/pkg/handlers/query.go
@@ -93,7 +93,7 @@ func Query(cfg *gabi.Config) http.HandlerFunc {
 		// Remember to check err afterwards.
 		cols, err := rows.Columns()
 		if err != nil {
-			cfg.Logger.Errorf("Unable to process database query: %s", err)
+			cfg.Logger.Errorf("Unable to process database columns: %s", err)
 			_ = queryErrorResponse(w, err)
 			return
 		}
@@ -117,7 +117,7 @@ func Query(cfg *gabi.Config) http.HandlerFunc {
 			// and you can use type introspection and type assertions
 			// to fetch the column into a typed variable.
 			if err != nil {
-				cfg.Logger.Errorf("Unable to process database query: %s", err)
+				cfg.Logger.Errorf("Unable to process database rows: %s", err)
 				_ = queryErrorResponse(w, err)
 				return
 			}
@@ -144,7 +144,7 @@ func Query(cfg *gabi.Config) http.HandlerFunc {
 
 		err = rows.Err()
 		if err != nil {
-			cfg.Logger.Errorf("Unable to process database query: %s", err)
+			cfg.Logger.Errorf("Unable to process database rows: %s", err)
 			_ = queryErrorResponse(w, err)
 			return
 		}

--- a/pkg/handlers/query_test.go
+++ b/pkg/handlers/query_test.go
@@ -365,7 +365,7 @@ func TestQuery(t *testing.T) {
 			},
 			400,
 			``,
-			`Unable to process database query: test`,
+			`Unable to process database rows: test`,
 		},
 		{
 			"valid query with database connection error",


### PR DESCRIPTION
Change error messages to better convey which parts of the query processing had failed more accurately.

No functional changes are intended.

Signed-off-by: Krzysztof Wilczyński <kwilczynski@redhat.com>