### PR TITLE
Update Go to version 1.19

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export PATH="/opt/go/1.19.5/bin:${PATH}"
+export PATH="/opt/go/1.19.11/bin:${PATH}"
 
 BASE_IMAGE="gabi"
 QUAY_IMAGE="quay.io/app-sre/${BASE_IMAGE}"

--- a/integration.sh
+++ b/integration.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export PATH="/opt/go/1.19.5/bin:${PATH}"
+export PATH="/opt/go/1.19.11/bin:${PATH}"
 
 {
     set +x

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export PATH="/opt/go/1.19.5/bin:${PATH}"
+export PATH="/opt/go/1.19.11/bin:${PATH}"
 
 readonly BASE_IMG="gabi"
 


### PR DESCRIPTION
Update Go to version ~1.20~1.19, especially to be able to build against Go ~1.20.6~1.19.11, which fixes the following vulnerability:

- [CVE-2023-29406](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2023-29406)

> The HTTP/1 client does not fully validate the contents of the Host header. A maliciously crafted Host header can inject additional headers or entire requests. With fix, the HTTP/1 client now refuses to send requests containing an invalid Request.Host or Request.URL.Host value.

No functional changes are intended.

Signed-off-by: Krzysztof Wilczyński <kwilczynski@redhat.com>