### PR TITLE
APPSRE-7875: Enable the --upstream-timeout argument

### DIFF
--- a/openshift/gabi.template.yaml
+++ b/openshift/gabi.template.yaml
@@ -68,8 +68,7 @@ objects:
           - --provider=openshift
           - --openshift-service-account=${GABI_INSTANCE}
           - --upstream=http://localhost:8080
-          # Reserved for future use.
-          # - --upstream-timeout=${OAUTH_PROXY_UPSTREAM_TIMEOUT}
+          - --upstream-timeout=${OAUTH_PROXY_UPSTREAM_TIMEOUT}
           - '--openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}", "namespace": "${NAMESPACE}"}}'
           - --tls-cert=/etc/tls/private/tls.crt
           - --tls-key=/etc/tls/private/tls.key


### PR DESCRIPTION
The upstream container image (see [openshift/origin-oauth-proxy](https://quay.io/repository/openshift/origin-oauth-proxy) on Quay) for the [openshift/oauth-proxy](https://github.com/openshift/oauth-proxy) service, that is Red Hat's fork of the OAuth2 Proxy, finally includes the changes needed to set the desired upstream timeout value.

Thus, enable this command-line argument when deploying a GABI instance now that the functionality is available.

Related:
- [APPSRE-7875](https://issues.redhat.com/browse/APPSRE-7875)
- https://github.com/app-sre/gabi/pull/57

Signed-off-by: Krzysztof Wilczyński <kwilczynski@redhat.com>