### PR TITLE
Set OpenShift Router timeout to a higher default value

### DIFF
--- a/openshift/gabi.template.yaml
+++ b/openshift/gabi.template.yaml
@@ -212,8 +212,7 @@ objects:
     annotations:
       cert-manager.io/issuer-kind: ${{CERT_MANAGER_ISSUER_KIND}}
       cert-manager.io/issuer-name: ${{CERT_MANAGER_ISSUER_NAME}}
-      # https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.1/html/managing_and_monitoring_process_server/configuring-openshift-connection-timeout-proc
-      haproxy.router.openshift.io/timeout: ${SERVER_TIMEOUT}
+      haproxy.router.openshift.io/timeout: ${OPENSHIFT_ROUTER_TIMEOUT}
     name: ${GABI_INSTANCE}
   spec:
     host: ${HOST}
@@ -243,8 +242,8 @@ parameters:
   value: 128Mi
 - name: MEMORY_LIMIT
   value: 256Mi
-- name: SERVER_TIMEOUT
-  value: 30s
+- name: OPENSHIFT_ROUTER_TIMEOUT
+  value: "600s"
 - name: OAUTH_PROXY_IMAGE_NAME
   value: quay.io/openshift/origin-oauth-proxy
 - name: OAUTH_PROXY_IMAGE_TAG


### PR DESCRIPTION
Set the timeout value for the OpenShift Router to 10 minutes, which is also the new default, to ensure that requests that take a little bit longer are not timed out and, as such, are interrupted abruptly.

While at it, rename the old variable from `SERVER_TIMEOUT` to `OPENSHIFT_ROUTER_TIMEOUT` to remove ambiguity about what is value this variable would otherwise set.

Related:
- [APPSRE-7875](https://issues.redhat.com/browse/APPSRE-7875)
- https://github.com/app-sre/gabi/pull/57
- https://github.com/app-sre/gabi/pull/60

Signed-off-by: Krzysztof Wilczyński [kwilczynski@redhat.com](mailto:kwilczynski@redhat.com)