### PR TITLE
Update OAuth2 Proxy default timeout value

### DIFF
--- a/openshift/gabi.template.yaml
+++ b/openshift/gabi.template.yaml
@@ -250,7 +250,7 @@ parameters:
 - name: OAUTH_PROXY_IMAGE_TAG
   value: "4.14.0"
 - name: OAUTH_PROXY_UPSTREAM_TIMEOUT
-  value: "30s"
+  value: "300s"
 - name: DB_DRIVER
   value: pgx
 - name: DB_WRITE


### PR DESCRIPTION
Update the default timeout value from 30 seconds to 5 minutes.

Related:

- [APPSRE-7875](https://issues.redhat.com/browse/APPSRE-7875)
- https://github.com/app-sre/gabi/pull/57
- https://github.com/app-sre/gabi/pull/60
- https://github.com/app-sre/gabi/pull/62

Signed-off-by: Krzysztof Wilczyński [kwilczynski@redhat.com](mailto:kwilczynski@redhat.com)