### PR TITLE
Drop hardcoded write timeout value from the HTTP server

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -97,10 +97,9 @@ func Run(logger *zap.SugaredLogger) error {
 	logger.Infof("HTTP server starting on port: %d", port)
 
 	server := &http.Server{
-		Addr:         net.JoinHostPort("", strconv.Itoa(port)),
-		Handler:      r,
-		ReadTimeout:  gabi.DefaultReadTimeout,
-		WriteTimeout: gabi.DefaultWriteTimeout,
+		Addr:        net.JoinHostPort("", strconv.Itoa(port)),
+		Handler:     r,
+		ReadTimeout: gabi.DefaultReadTimeout,
 	}
 	if err := server.ListenAndServe(); err != nil {
 		return fmt.Errorf("unable to start HTTP server: %w", err)

--- a/pkg/gabi.go
+++ b/pkg/gabi.go
@@ -18,9 +18,6 @@ const (
 	// The total time it takes to read the request from the client.
 	DefaultReadTimeout = 1 * time.Minute
 
-	// The total time it takes to send a response back to the client.
-	DefaultWriteTimeout = 5 * time.Minute
-
 	// The total time it takes to execute the request.
 	DefaultRequestTimeout = 2 * time.Minute
 )


### PR DESCRIPTION
Remove the hardcoded write timeout value of **5 minutes** from the HTTP server. This timeout served as the total allotted timeout that GABI was allowed to spend on processing a request.

However, multiple other services are involved when a request is set against a particular GABI instance, and as such, setting a hardcoded write timeout value removed some flexibility from being able to set unreasonably high timeouts when such a need arises.

The following timeout values are currently the defaults:

* OpenShift Router: **10 minutes**
* OAuth2 Proxy: **5 minutes**
* GABI request: **30 seconds**

Related:

- [APPSRE-7875](https://issues.redhat.com/browse/APPSRE-7875)
- https://github.com/app-sre/gabi/pull/57
- https://github.com/app-sre/gabi/pull/60

Signed-off-by: Krzysztof Wilczyński [kwilczynski@redhat.com](mailto:kwilczynski@redhat.com)