### PR TITLE
Add CPU_LIMIT and OAUTH_PROXY_CPU_LIMIT

### DIFF
--- a/openshift/gabi.template.yaml
+++ b/openshift/gabi.template.yaml
@@ -59,6 +59,7 @@ objects:
             successThreshold: 1
           resources:
             limits:
+              cpu: ${OAUTH_PROXY_CPU_LIMIT}
               memory: 64Mi
             requests:
               cpu: ${OAUTH_PROXY_CPU_REQUEST}
@@ -162,6 +163,7 @@ objects:
               cpu: ${CPU_REQUEST}
               memory: ${MEMORY_REQUEST}
             limits:
+              cpu: ${CPU_LIMIT}
               memory: ${MEMORY_LIMIT}
         volumes:
         - name: gabi-tls
@@ -235,6 +237,8 @@ parameters:
   value: "1"
 - name: CPU_REQUEST
   value: 100m
+- name: CPU_LIMIT
+  value: 100m
 - name: MEMORY_REQUEST
   value: 128Mi
 - name: MEMORY_LIMIT
@@ -248,6 +252,8 @@ parameters:
 - name: OAUTH_PROXY_UPSTREAM_TIMEOUT
   value: "300s"
 - name: OAUTH_PROXY_CPU_REQUEST
+  value: 100m
+- name: OAUTH_PROXY_CPU_LIMIT
   value: 100m
 - name: DB_DRIVER
   value: pgx


### PR DESCRIPTION
I set them to be the same as the requests, because gabi doesn't appear to be CPU-bound. I checked one cluster's usage via PromQL:

```promql
max_over_time(pod:container_cpu_usage:sum{pod=~"gabi.*"}[24h:5m])
```

and saw 0.02 as the highest number across the last couple of weeks of metrics, so I figure setting the same as the request seems a reasonable default.