### PR TITLE
fix ci in rhel8

### DIFF
--- a/integration.sh
+++ b/integration.sh
@@ -16,6 +16,8 @@ EOF
 
 export QUAY_TOKEN
 
+export DOCKER_HOST=unix:///run/user/${UID}/podman/podman.sock
+
 grep -oE 'Test[A-Za-z0-9]{,}' test/integration_test.go | while read -r test; do
     echo "Running test: ${test}"
     go test -tags integration -count 1 -timeout 300s -run "^${test}$" ./test/...

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -10,11 +10,14 @@ readonly BASE_IMG="gabi"
 
 {
     set +x
-    docker login quay.io -u "${QUAY_USER}" -p "${QUAY_TOKEN}"
+    podman login quay.io -u "${QUAY_USER}" -p "${QUAY_TOKEN}"
 }
 
 go test ./...
 
-./integration.sh
+podman pull quay.io/app-sre/gnomock-cleaner:latest
+podman tag quay.io/app-sre/gnomock-cleaner:latest docker.io/orlangure/gnomock-cleaner:latest
 
-BUILD_CMD="docker build" IMG="${BASE_IMG}:check" make docker-build
+podman system service -t 0 & ./integration.sh
+
+BUILD_CMD="podman build" IMG="${BASE_IMG}:check" make docker-build


### PR DESCRIPTION
enable podman.sock as DOCKER_HOST, use mirrored gnomock-cleaner image.