### PR TITLE
[WIP] Logging, auditing, warnings, and PingContext failure handling for switch DB

### DIFF
--- a/pkg/audit/audit.go
+++ b/pkg/audit/audit.go
@@ -8,6 +8,7 @@ type QueryData struct {
 	Namespace string
 	Pod       string
 	Timestamp int64
+	DBName    string
 }
 
 type Audit interface {

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -92,7 +92,7 @@ func Run(logger *zap.SugaredLogger) error {
 	r := mux.NewRouter()
 	r.Handle("/healthcheck", logHandler(healthLogOutput, handlers.Healthcheck(cfg))).Methods("GET")
 	r.Handle("/query", logHandler(defaultLogOutput, queryHandler)).Methods("POST")
-	r.Handle("/dbname", logHandler(defaultLogOutput, handlers.GetCurrentDBName(cfg))).Methods("GET")
+	r.Handle("/dbname", logHandler(defaultLogOutput, handlers.GetDBName(cfg))).Methods("GET")
 	r.Handle("/dbname/switch", logHandler(defaultLogOutput, handlers.SwitchDBName(cfg))).Methods("POST")
 
 	port := 8080

--- a/pkg/handlers/getdbname.go
+++ b/pkg/handlers/getdbname.go
@@ -3,15 +3,26 @@ package handlers
 import (
 	"encoding/json"
 	"net/http"
+	"os"
 
 	gabi "github.com/app-sre/gabi/pkg"
 	"github.com/app-sre/gabi/pkg/models"
 )
 
-func GetCurrentDBName(cfg *gabi.Config) http.Handler {
+func GetDBName(cfg *gabi.Config) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		dbName := cfg.DBEnv.GetCurrentDBName()
+		defaultDBName := os.Getenv("DB_NAME")
+
+		response := models.DBNameResponse{DBName: dbName}
+
+		if dbName != defaultDBName {
+			warning := "Current database differs from the default"
+			cfg.Logger.Warnf(warning)
+			response.Warnings = append(response.Warnings, warning)
+		}
+
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(models.DBNameResponse{DBName: dbName})
+		json.NewEncoder(w).Encode(response)
 	})
 }

--- a/pkg/handlers/healthcheck.go
+++ b/pkg/handlers/healthcheck.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/etherlabsio/healthcheck/v2"
@@ -14,17 +15,25 @@ import (
 const healthcheckTimeout = 5 * time.Second
 
 func Healthcheck(cfg *gabi.Config) http.Handler {
+	defaultDBName := os.Getenv("DB_NAME")
 	return healthcheck.Handler(
 		healthcheck.WithTimeout(healthcheckTimeout),
 		healthcheck.WithChecker(
 			"database", healthcheck.CheckerFunc(
 				func(ctx context.Context) error {
+					dbName := cfg.DBEnv.GetCurrentDBName()
 					err := cfg.DB.PingContext(ctx)
 					if err != nil {
 						l := "Unable to connect to the database"
 						cfg.Logger.Errorf("%s: %s", l, err)
 						return errors.New(l)
 					}
+
+					if dbName != defaultDBName {
+						l := "Current database differs from the default"
+						cfg.Logger.Warnf(l)
+					}
+
 					return nil
 				},
 			),

--- a/pkg/handlers/query.go
+++ b/pkg/handlers/query.go
@@ -29,7 +29,16 @@ func Query(cfg *gabi.Config) http.HandlerFunc {
 		var (
 			base64Mode byte
 			request    models.QueryRequest
+			warnings   []string
 		)
+
+		defaultDBName := os.Getenv("DB_NAME")
+		currentDBName := cfg.DBEnv.GetCurrentDBName()
+		if currentDBName != defaultDBName {
+			l := "Current database differs from the default"
+			cfg.Logger.Warnf(l)
+			warnings = append(warnings, l)
+		}
 
 		if s := r.URL.Query().Get("base64_results"); s != "" {
 			if ok, err := strconv.ParseBool(s); err == nil && ok {
@@ -159,7 +168,8 @@ func Query(cfg *gabi.Config) http.HandlerFunc {
 		w.Header().Set("Cache-Control", "private, no-store")
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_ = json.NewEncoder(w).Encode(&models.QueryResponse{
-			Result: result,
+			Result:   result,
+			Warnings: warnings,
 		})
 	}
 }

--- a/pkg/handlers/query_test.go
+++ b/pkg/handlers/query_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -22,18 +23,20 @@ import (
 )
 
 func TestQuery(t *testing.T) {
-	t.Parallel()
+	//t.Parallel()
 
 	cases := []struct {
-		description string
-		database    func() (*sql.DB, sqlmock.Sqlmock)
-		mock        func(sqlmock.Sqlmock)
-		context     func() context.Context
-		parameters  func(*http.Request)
-		request     func() *bytes.Buffer
-		code        int
-		body        string
-		want        string
+		description   string
+		database      func() (*sql.DB, sqlmock.Sqlmock)
+		mock          func(sqlmock.Sqlmock)
+		context       func() context.Context
+		parameters    func(*http.Request)
+		request       func() *bytes.Buffer
+		defaultDBName string
+		dbName        string
+		code          int
+		body          string
+		want          string
 	}{
 		{
 			"valid query",
@@ -56,6 +59,8 @@ func TestQuery(t *testing.T) {
 			func() *bytes.Buffer {
 				return bytes.NewBufferString(`{"query": "select 1;"}`)
 			},
+			"default_db",
+			"default_db",
 			200,
 			`{"result":[["?column?"],["1"]],"error":""}`,
 			``,
@@ -82,6 +87,8 @@ func TestQuery(t *testing.T) {
 			func() *bytes.Buffer {
 				return bytes.NewBufferString(`{"query": "select 1;"}`)
 			},
+			"default_db",
+			"default_db",
 			200,
 			`{"result":[["?column?"],["2"]],"error":""}`,
 			``,
@@ -108,6 +115,8 @@ func TestQuery(t *testing.T) {
 			func() *bytes.Buffer {
 				return bytes.NewBufferString(`{"query": "select 1;"}`)
 			},
+			"default_db",
+			"default_db",
 			200,
 			`{"result":[["?column?"],["1"]],"error":""}`,
 			``,
@@ -135,6 +144,8 @@ func TestQuery(t *testing.T) {
 			func() *bytes.Buffer {
 				return bytes.NewBufferString(`{"query": "c2VsZWN0IDE7"}`)
 			},
+			"default_db",
+			"default_db",
 			200,
 			`{"result":[["?column?"],["1"]],"error":""}`,
 			``,
@@ -162,6 +173,8 @@ func TestQuery(t *testing.T) {
 			func() *bytes.Buffer {
 				return bytes.NewBufferString(`{"query": "select 1;"}`)
 			},
+			"default_db",
+			"default_db",
 			200,
 			`{"result":[["?column?"],["1"]],"error":""}`,
 			``,
@@ -189,6 +202,8 @@ func TestQuery(t *testing.T) {
 			func() *bytes.Buffer {
 				return bytes.NewBufferString(`{"query": "select 1;"}`)
 			},
+			"default_db",
+			"default_db",
 			200,
 			`{"result":[["?column?"],["MQ=="]],"error":""}`,
 			``,
@@ -216,6 +231,8 @@ func TestQuery(t *testing.T) {
 			func() *bytes.Buffer {
 				return bytes.NewBufferString(`{"query": "select 1;"}`)
 			},
+			"default_db",
+			"default_db",
 			200,
 			`{"result":[["?column?"],["1"]],"error":""}`,
 			``,
@@ -241,6 +258,8 @@ func TestQuery(t *testing.T) {
 			func() *bytes.Buffer {
 				return bytes.NewBufferString(`{"query": ""}`)
 			},
+			"default_db",
+			"default_db",
 			200,
 			`{"result":[null],"error":""}`,
 			``,
@@ -265,6 +284,8 @@ func TestQuery(t *testing.T) {
 			func() *bytes.Buffer {
 				return bytes.NewBufferString(`{"query":"select 1;"}`)
 			},
+			"default_db",
+			"default_db",
 			400,
 			`{"result":null,"error":"test"}`,
 			``,
@@ -289,6 +310,8 @@ func TestQuery(t *testing.T) {
 			func() *bytes.Buffer {
 				return bytes.NewBufferString(`{"query":"select 1;"}`)
 			},
+			"default_db",
+			"default_db",
 			400,
 			``,
 			`Unable to query database: test`,
@@ -311,6 +334,8 @@ func TestQuery(t *testing.T) {
 			func() *bytes.Buffer {
 				return bytes.NewBufferString(`{"query":"select 1;"}`)
 			},
+			"default_db",
+			"default_db",
 			400,
 			``,
 			`Unable to start database transaction: test`,
@@ -336,6 +361,8 @@ func TestQuery(t *testing.T) {
 			func() *bytes.Buffer {
 				return bytes.NewBufferString(`{"query": "select 1;"}`)
 			},
+			"default_db",
+			"default_db",
 			400,
 			``,
 			`Unable to commit database changes: test`,
@@ -363,6 +390,8 @@ func TestQuery(t *testing.T) {
 			func() *bytes.Buffer {
 				return bytes.NewBufferString(`{"query": "select * from test;"}`)
 			},
+			"default_db",
+			"default_db",
 			400,
 			``,
 			`Unable to process database rows: test`,
@@ -386,6 +415,8 @@ func TestQuery(t *testing.T) {
 			func() *bytes.Buffer {
 				return bytes.NewBufferString(`{"query": "select 1;"}`)
 			},
+			"default_db",
+			"default_db",
 			503,
 			`Unable to connect to the database`,
 			``,
@@ -408,6 +439,8 @@ func TestQuery(t *testing.T) {
 			func() *bytes.Buffer {
 				return &bytes.Buffer{}
 			},
+			"default_db",
+			"default_db",
 			400,
 			`Request body cannot be empty`,
 			``,
@@ -430,6 +463,8 @@ func TestQuery(t *testing.T) {
 			func() *bytes.Buffer {
 				return bytes.NewBufferString(`{"query: "select 1;"}`)
 			},
+			"default_db",
+			"default_db",
 			400,
 			``,
 			`Unable to decode request body`,
@@ -452,6 +487,8 @@ func TestQuery(t *testing.T) {
 			func() *bytes.Buffer {
 				return bytes.NewBufferString(`{"query": -1}`)
 			},
+			"default_db",
+			"default_db",
 			400,
 			``,
 			`Unable to decode request body`,
@@ -476,8 +513,37 @@ func TestQuery(t *testing.T) {
 			func() *bytes.Buffer {
 				return bytes.NewBufferString(`{"query": "dGhpcyBpcyBhIHRlc3Q=="}`)
 			},
+			"default_db",
+			"default_db",
 			400,
 			`Unable to decode Base64-encoded query`,
+			``,
+		},
+		{
+			"database name differs from the default",
+			func() (*sql.DB, sqlmock.Sqlmock) {
+				db, mock, _ := sqlmock.New()
+				return db, mock
+			},
+			func(mock sqlmock.Sqlmock) {
+				rows := sqlmock.NewRows([]string{"?column?"}).AddRow("1")
+				mock.ExpectBegin()
+				mock.ExpectQuery(`select 1;`).WillReturnRows(rows)
+				mock.ExpectCommit()
+			},
+			func() context.Context {
+				return context.TODO()
+			},
+			func(r *http.Request) {
+				// No-op.
+			},
+			func() *bytes.Buffer {
+				return bytes.NewBufferString(`{"query": "select 1;"}`)
+			},
+			"default_db",
+			"test_db",
+			200,
+			`{"result":[["?column?"],["1"]],"warnings":["Current database differs from the default"],"error":""}`,
 			``,
 		},
 	}
@@ -485,9 +551,14 @@ func TestQuery(t *testing.T) {
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
+			//t.Parallel()
 
 			var body, output bytes.Buffer
+
+			os.Setenv("DB_NAME", tc.defaultDBName)
+			defer os.Unsetenv("DB_NAME")
+
+			dbEnv := &gabidb.Env{Name: tc.dbName}
 
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest(http.MethodGet, "/", tc.request())
@@ -501,7 +572,7 @@ func TestQuery(t *testing.T) {
 			tc.mock(mock)
 			tc.parameters(r)
 
-			expected := &gabi.Config{DB: db, DBEnv: &gabidb.Env{}, Logger: logger, Encoder: encoder}
+			expected := &gabi.Config{DB: db, DBEnv: dbEnv, Logger: logger, Encoder: encoder}
 			Query(expected).ServeHTTP(w, r.WithContext(tc.context()))
 
 			actual := w.Result()

--- a/pkg/handlers/switchdbname.go
+++ b/pkg/handlers/switchdbname.go
@@ -1,8 +1,10 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
+	"time"
 
 	gabi "github.com/app-sre/gabi/pkg"
 	"github.com/app-sre/gabi/pkg/models"
@@ -16,10 +18,25 @@ func SwitchDBName(cfg *gabi.Config) http.Handler {
 			return
 		}
 
+		oldDBName := cfg.DBEnv.GetCurrentDBName()
 		cfg.DBEnv.OverrideDBName(req.DBName)
+		newDBName := cfg.DBEnv.GetCurrentDBName()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if err := cfg.DB.PingContext(ctx); err != nil {
+			cfg.Logger.Errorf("Failed to ping new database %s, falling back to %s: %s", newDBName, oldDBName, err)
+			cfg.DBEnv.OverrideDBName(oldDBName)
+			newDBName = oldDBName
+		} else {
+			cfg.Logger.Infof("Database name switched from %s to %s", oldDBName, newDBName)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]string{"db_name": cfg.DBEnv.GetCurrentDBName()})
+		if err := json.NewEncoder(w).Encode(map[string]string{"db_name": newDBName}); err != nil {
+			cfg.Logger.Errorf("Failed to encode response: %s", err)
+		}
 	})
 }

--- a/pkg/middleware/audit.go
+++ b/pkg/middleware/audit.go
@@ -84,6 +84,7 @@ func Audit(cfg *gabi.Config) Middleware {
 				Query:     request.Query,
 				User:      user,
 				Timestamp: now.Unix(),
+				DBName:    cfg.DBEnv.GetCurrentDBName(),
 			}
 			_ = cfg.LoggerAudit.Write(ctx, query)
 

--- a/pkg/models/dbname.go
+++ b/pkg/models/dbname.go
@@ -5,5 +5,6 @@ type SwitchDBNameRequest struct {
 }
 
 type DBNameResponse struct {
-	DBName string `json:"db_name"`
+	DBName   string   `json:"db_name"`
+	Warnings []string `json:"warnings,omitempty"`
 }

--- a/pkg/models/query.go
+++ b/pkg/models/query.go
@@ -5,6 +5,7 @@ type QueryRequest struct {
 }
 
 type QueryResponse struct {
-	Result [][]string `json:"result"`
-	Error  string     `json:"error"`
+	Result   [][]string `json:"result"`
+	Warnings []string   `json:"warnings,omitempty"`
+	Error    string     `json:"error"`
 }


### PR DESCRIPTION
- adds log output when switching db name
- adds dbname in audit data
- after OverrideDBName, try a DB.PingContext, if it fails, fall back to its last value.
- when current db name is different with env DB_NAME, returns a warning saying current db is not the default one in the response json