### PR TITLE
Add a helm chart to deploy GABI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build linux clean test
+.PHONY: build linux clean test helm
 
 all: build
 
@@ -13,3 +13,11 @@ clean:
 
 test:
 	go test ./...
+
+helm:
+	@if [ -z "$(HELM_PARAMS)" ]; then \
+	  echo "Error: HELM_PARAMS variables is not set. Use 'make helm HELM_PARAMS=\"--set splunk.token=<token> --set splunk.endpoint=<endpoint>\"'"; \
+	  exit 1; \
+	else \
+	  helm template helm/ ${HELM_PARAMS}; \
+	fi;

--- a/helm/.helmignore
+++ b/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: gabi
+description: Helm chart to deploy GABI
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,0 +1,152 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{.Values.gabi.instance}}
+  name: {{.Values.gabi.instance}}
+  annotations:
+    ignore-check.kube-linter.io/minimum-three-replicas: "GABI does not need 3 replicas"
+    ignore-check.kube-linter.io/unset-cpu-requirements: "no cpu limits"
+spec:
+  replicas: {{.Values.gabi.replicas}}
+  selector:
+    matchLabels:
+      app: {{.Values.gabi.instance}}
+  template:
+    metadata:
+      labels:
+        app: {{.Values.gabi.instance}}
+    spec:
+      serviceAccountName: {{.Values.gabi.instance}}
+      containers:
+      - name: oauth-proxy
+        image: "{{.Values.oauth_proxy.image}}:{{.Values.oauth_proxy.tag}}"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 3000
+          name: http
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /oauth/healthz
+            port: http
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          failureThreshold: 3
+          periodSeconds: 10
+          successThreshold: 1
+        livenessProbe:
+          httpGet:
+            path: /oauth/healthz
+            port: http
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          failureThreshold: 3
+          periodSeconds: 10
+          successThreshold: 1
+        resources: {{.Values.oauth_proxy.resources | toYaml | nindent 10}}
+        args:
+        - --https-address=:3000
+        - --provider=openshift
+        - --openshift-service-account={{.Values.gabi.instance}}
+        - --upstream=http://localhost:8080
+        - --upstream-timeout={{.Values.oauth_proxy.upstream_timeout}}
+        - '--openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get", "name": "{{.Values.namespace}}", "namespace": "{{.Values.namespace}}"}}'
+        - --tls-cert=/etc/tls/private/tls.crt
+        - --tls-key=/etc/tls/private/tls.key
+        - --cookie-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: gabi-tls
+      - name: {{.Values.gabi.instance}}
+        image: "{{.Values.gabi.image}}:{{.Values.gabi.tag}}"
+        readinessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          failureThreshold: 3
+          periodSeconds: 10
+          successThreshold: 1
+        livenessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          failureThreshold: 3
+          periodSeconds: 10
+          successThreshold: 1
+        volumeMounts:
+        - name: gabi-config
+          mountPath: /config
+        env:
+        - name: HOST
+          value: {{.Values.gabi.host}}
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ENVIRONMENT
+          value: {{.Values.environment}}
+        - name: NAMESPACE
+          value: {{.Values.namespace}}
+        - name: SPLUNK_INDEX
+          value: {{.Values.splunk.index}}
+        - name: SPLUNK_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: SPLUNK_TOKEN
+              name: "{{.Values.gabi.instance}}-splunk"
+        - name: SPLUNK_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              key: SPLUNK_ENDPOINT
+              name: "{{.Values.gabi.instance}}-splunk"
+        - name: DB_DRIVER
+          value: {{.Values.gabi.db_driver}}
+        - name: DB_WRITE
+          value: "{{.Values.gabi.db_write}}"
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: db.host
+              name: {{.Values.gabi.aws_rds_secret_name}}
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: db.port
+              name: {{.Values.gabi.aws_rds_secret_name}}
+        - name: DB_USER
+          valueFrom:
+            secretKeyRef:
+              key: db.user
+              name: {{.Values.gabi.aws_rds_secret_name}}
+        - name: DB_PASS
+          valueFrom:
+            secretKeyRef:
+              key: db.password
+              name: {{.Values.gabi.aws_rds_secret_name}}
+        - name: DB_NAME
+          valueFrom:
+            secretKeyRef:
+              key: db.name
+              name: {{.Values.gabi.aws_rds_secret_name}}
+        - name: CONFIG_FILE_PATH
+          value: {{.Values.gabi.config_file_path}}
+        - name: REQUEST_TIMEOUT
+          value: {{.Values.gabi.request_timeout}}
+        resources: {{.Values.gabi.resources | toYaml | nindent 10}}
+      volumes:
+      - name: "{{.Values.gabi.instance}}-tls"
+        secret:
+          secretName: "{{.Values.gabi.instance}}-tls"
+      - name: gabi-config
+        configMap:
+          optional: true
+          name: {{.Values.gabi.instance}}

--- a/helm/templates/route.yaml
+++ b/helm/templates/route.yaml
@@ -1,0 +1,21 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{.Values.gabi.instance}}
+  annotations:
+    {{- if .Values.cert_manager.enable}}
+    cert-manager.io/issuer-kind: {{.Values.cert_manager.issuer.kind}}
+    cert-manager.io/issuer-name: {{.Values.cert_manager.issuer.name}}
+    {{- end}}
+    haproxy.router.openshift.io/timeout: {{.Values.openshift_router_timeout}}
+spec:
+  host: {{.Values.gabi.host }}
+  port:
+    targetPort: http
+  to:
+    kind: Service
+    name: {{.Values.gabi.instance}}-external
+    weight: 100
+  tls:
+    termination: Reencrypt
+    insecureEdgeTerminationPolicy: Redirect

--- a/helm/templates/secrets.yaml
+++ b/helm/templates/secrets.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{.Values.gabi.instance}}-splunk
+type: Opaque
+stringData:
+  SPLUNK_TOKEN: {{ required "splunk.token is required" .Values.splunk.token }}
+  SPLUNK_ENDPOINT: {{ required "splunk.endpoint is required" .Values.splunk.endpoint }}

--- a/helm/templates/service-account.yaml
+++ b/helm/templates/service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.gabi.instance}}
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirectreference.prometheus: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"{{.Values.gabi.instance}}"'

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{.Values.gabi.instance}}-internal
+spec:
+  clusterIP: None
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+  selector:
+    app: {{.Values.gabi.instance}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{.Values.gabi.instance}}-external
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: {{.Values.gabi.instance}}-tls
+spec:
+  ports:
+  - name: http
+    port: 3000
+    protocol: TCP
+    targetPort: http
+  selector:
+    app: {{.Values.gabi.instance}}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,50 @@
+environment: development
+namespace: gabi
+
+openshift_router_timeout: 600s
+
+gabi:
+  instance: gabi-instance
+  image: quay.io/app-sre/gabi
+  tag: latest
+  replicas: 1
+  pod_name: gabi-staging
+  resources:
+    requests:
+      memory: 128Mi
+      cpu: 100m
+    limits:
+      memory: 256Mi
+  db_driver: pgx
+  db_write: false
+  host: example.com
+  aws_rds_secret_name: db-creds
+  request_timeout: 30s
+  config_file_path: /config/config.json
+
+oauth_proxy:
+  image: quay.io/openshift/origin-oauth-proxy
+  tag: 4.10.0
+  upstream_timeout: 300s
+  resources:
+    requests:
+      memory: 32Mi
+      cpu: 100m
+    limits:
+      memory: 64Mi
+
+splunk:
+  index: app-sre
+  secret_name: splunk-creds
+  # endpoint: REQUIRED
+  # token: REQUIRED
+
+cluster_scope_rbac:
+  create: true
+
+# Options for the cert-manager annotations
+cert_manager:
+  enable: false
+  issuer:
+    kind: ClusterIssuer
+    name: letsencrypt-prod-http


### PR DESCRIPTION
The main reason for this change is to add logic to set the cert-manager annotations. 
Gabi instances using the default IngressController domain do not need to request specific certificates. Requesting them can cause a rate limit issue since all the subdomains are part of the same "exact set of hostnames". 

https://letsencrypt.org/docs/rate-limits/#new-certificates-per-exact-set-of-hostnames
