### PR TITLE
Change gabi svc tls name

### DIFF
--- a/openshift/gabi.template.yaml
+++ b/openshift/gabi.template.yaml
@@ -186,7 +186,7 @@ objects:
   metadata:
     name: ${GABI_INSTANCE}-external
     annotations:
-      service.alpha.openshift.io/serving-cert-secret-name: ${GABI_INSTANCE}-tls
+      service.alpha.openshift.io/serving-cert-secret-name: ${GABI_INSTANCE}-svc-tls
   spec:
     ports:
     - name: http


### PR DESCRIPTION
The secret created by the annotation in the `Service` collides with the secret created by Cert-manager in the `Route`.

Changing the name will store the certificates in different secrets. 