### PR TITLE
Fix integration tests

### DIFF
--- a/integration.sh
+++ b/integration.sh
@@ -4,20 +4,15 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export PATH="/opt/go/1.19.11/bin:${PATH}"
-
-{
-    set +x
-    QUAY_TOKEN=$(cat <<-EOF | base64 | tr -d '\n'
-{"username":"${QUAY_USER}","password":"${QUAY_TOKEN}"}
-EOF
-)
-}
+export PATH="/opt/go/1.22.5/bin:${PATH}"
 
 export QUAY_TOKEN
 
 export DOCKER_HOST=unix:///run/user/${UID}/podman/podman.sock
 
+# Pull these images using the auth in the jenkins nodes
+podman pull registry.redhat.io/rhel9/postgresql-16:9.6
+podman pull quay.io/app-sre/splunk:latest
 grep -oE 'Test[A-Za-z0-9]{,}' test/integration_test.go | while read -r test; do
     echo "Running test: ${test}"
     go test -tags integration -count 1 -timeout 300s -run "^${test}$" ./test/...

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -8,11 +8,6 @@ export PATH="/opt/go/1.19.11/bin:${PATH}"
 
 readonly QUAY_IMAGE="quay.io/app-sre/gabi"
 
-{
-    set +x
-    podman login quay.io -u "${QUAY_USER}" -p "${QUAY_TOKEN}"
-}
-
 go test ./...
 
 podman pull quay.io/app-sre/gnomock-cleaner:latest


### PR DESCRIPTION
Update gnomock integration tests to use Red Hat PostgreSQL 16 image
(registry.redhat.io/rhel9/postgresql-16) instead of the standard
docker.io/library/postgres image (via the quay.io/app-sre/postgres)
mirror and fix splunk integration tests.

Changes:
- Let the pull auth in PR checks be done via jenkins nodes pull
  credentials to avoid handling multiple logins to different repos
- Use POSTGRESQL_* environment variables for Red Hat image compatibility
- Add custom healthcheck for PostgreSQL using correct credentials
- Add SPLUNK_GENERAL_TERMS environment variable to fix Splunk container startup

APPSRE-12463

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>

Assisted-by: Claude noreply@anthropic.com