### PR TITLE
fix: prevent oauth-proxy bypass via X-Forwarded-User spoof

### DIFF
--- a/openshift/gabi.template.yaml
+++ b/openshift/gabi.template.yaml
@@ -69,6 +69,7 @@ objects:
           - '--openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}", "namespace": "${NAMESPACE}"}}'
           - --tls-cert=/etc/tls/private/tls.crt
           - --tls-key=/etc/tls/private/tls.key
+          - --bypass-auth-for=^/healthcheck$
           - --cookie-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
           volumeMounts:
           - mountPath: /etc/tls/private
@@ -78,8 +79,8 @@ objects:
           readinessProbe:
             httpGet:
               path: /healthcheck
-              port: 8080
-              scheme: HTTP
+              port: 3000
+              scheme: HTTPS
             initialDelaySeconds: 5
             timeoutSeconds: 1
             failureThreshold: 3
@@ -88,8 +89,8 @@ objects:
           livenessProbe:
             httpGet:
               path: /healthcheck
-              port: 8080
-              scheme: HTTP
+              port: 3000
+              scheme: HTTPS
             initialDelaySeconds: 5
             timeoutSeconds: 1
             failureThreshold: 3
@@ -174,19 +175,7 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    name: ${GABI_INSTANCE}-internal
-  spec:
-    clusterIP: None
-    ports:
-    - name: http
-      port: 8080
-      protocol: TCP
-    selector:
-      app: ${GABI_INSTANCE}
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: ${GABI_INSTANCE}-external
+    name: ${GABI_INSTANCE}
     annotations:
       service.alpha.openshift.io/serving-cert-secret-name: ${GABI_INSTANCE}-svc-tls
   spec:
@@ -208,7 +197,7 @@ objects:
       targetPort: http
     to:
       kind: Service
-      name: ${GABI_INSTANCE}-external
+      name: ${GABI_INSTANCE}
       weight: 100
     tls:
       termination: reencrypt

--- a/openshift/post-deploy-tests.template.yaml
+++ b/openshift/post-deploy-tests.template.yaml
@@ -32,10 +32,11 @@ objects:
               - --silent
               - --show-error
               - --fail
-              - http://$(HOST):8080/healthcheck
+              - --insecure
+              - https://$(HOST):3000/healthcheck
             env:
             - name: HOST
-              value: ${GABI_INSTANCE}-internal.${NAMESPACE}.svc.cluster.local
+              value: ${GABI_INSTANCE}.${NAMESPACE}.svc.cluster.local
             resources: "${{RESOURCES}}"
 parameters:
 - name: NAMESPACE

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -108,7 +108,7 @@ func Run(logger *zap.SugaredLogger) error {
 	logger.Infof("HTTP server starting on port: %d", port)
 
 	server := &http.Server{
-		Addr:        net.JoinHostPort("", strconv.Itoa(port)),
+		Addr:        net.JoinHostPort("127.0.0.1", strconv.Itoa(port)),
 		Handler:     r,
 		ReadTimeout: gabi.DefaultReadTimeout,
 	}


### PR DESCRIPTION
## Summary

- Bind backend HTTP server to `127.0.0.1:8080` (localhost only) so only the oauth-proxy sidecar in the same pod can reach it — external pods can no longer spoof `X-Forwarded-User`
- Add `--bypass-auth-for=^/healthcheck$` to oauth-proxy so kubelet probes can reach `/healthcheck` without authentication
- Route gabi container health probes through oauth-proxy on port 3000/HTTPS instead of directly hitting port 8080/HTTP
- Remove the `${GABI_INSTANCE}-internal` headless Service that exposed port 8080 to the cluster network, rename `${GABI_INSTANCE}-external` → `${GABI_INSTANCE}`
- Update post-deploy tests to use the (renamed) service on port 3000/HTTPS

Addresses [APPSRE-15020](https://redhat.atlassian.net/browse/APPSRE-15020) (Glasswing FIND-001: cluster-internal Service exposes raw port 8080, allowing X-Forwarded-User spoof to bypass oauth-proxy).

## Test plan

- [x] Deployed patched template to staging (`gabi-stage`)
- [x] Verified `--bypass-auth-for` works: `GET /healthcheck` through oauth-proxy returns 200 without auth
- [x] Verified `/query` through oauth-proxy still returns 403 without auth
- [x] Pod rolls out healthy (2/2 Running) with probes on port 3000/HTTPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)