### PR TITLE
fix: harden dbname routes, DSN validation, and request body limits (APPSRE-15060)

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -94,23 +94,40 @@ func Run(logger *zap.SugaredLogger) error {
 		alice.Constructor(middleware.Audit(cfg)),
 		alice.Constructor(middleware.ContextTimeout(timeout)),
 	)
+	// /dbname and /dbname/switch must enforce the same identity and expiry
+	// gates as /query. GET /dbname has no body, so it omits Audit; switch
+	// emits its own fail-closed Splunk event inside the handler (FIND-002).
+	dbnameChain := alice.New(
+		alice.Constructor(middleware.Recovery(cfg)),
+		alice.Constructor(middleware.Authorization(cfg)),
+		alice.Constructor(middleware.Expiration(cfg)),
+	)
+	switchChain := alice.New(
+		alice.Constructor(middleware.Recovery(cfg)),
+		alice.Constructor(middleware.Authorization(cfg)),
+		alice.Constructor(middleware.Expiration(cfg)),
+		alice.Constructor(middleware.Timeout(timeout)),
+	)
 	queryHandler := queryChain.Then(handlers.Query(cfg))
 	streamHandler := streamChain.Then(handlers.StreamQuery(cfg))
+	dbnameHandler := dbnameChain.Then(handlers.GetCurrentDBName(cfg))
+	switchHandler := switchChain.Then(handlers.SwitchDBName(cfg))
 
 	r := mux.NewRouter()
 	r.Handle("/healthcheck", logHandler(healthLogOutput, handlers.Healthcheck(cfg))).Methods("GET")
 	r.Handle("/query", logHandler(defaultLogOutput, queryHandler)).Methods("POST")
 	r.Handle("/streamquery", logHandler(defaultLogOutput, streamHandler)).Methods("POST")
-	r.Handle("/dbname", logHandler(defaultLogOutput, handlers.GetCurrentDBName(cfg))).Methods("GET")
-	r.Handle("/dbname/switch", logHandler(defaultLogOutput, handlers.SwitchDBName(cfg))).Methods("POST")
+	r.Handle("/dbname", logHandler(defaultLogOutput, dbnameHandler)).Methods("GET")
+	r.Handle("/dbname/switch", logHandler(defaultLogOutput, switchHandler)).Methods("POST")
 
 	port := 8080
 	logger.Infof("HTTP server starting on port: %d", port)
 
 	server := &http.Server{
-		Addr:        net.JoinHostPort("127.0.0.1", strconv.Itoa(port)),
-		Handler:     r,
-		ReadTimeout: gabi.DefaultReadTimeout,
+		Addr:           net.JoinHostPort("127.0.0.1", strconv.Itoa(port)),
+		Handler:        r,
+		ReadTimeout:    gabi.DefaultReadTimeout,
+		MaxHeaderBytes: gabi.MaxHeaderBytes,
 	}
 	if err := server.ListenAndServe(); err != nil {
 		return fmt.Errorf("unable to start HTTP server: %w", err)

--- a/pkg/env/db/db.go
+++ b/pkg/env/db/db.go
@@ -66,6 +66,9 @@ func (d *Env) Populate() error {
 	if name == "" {
 		return &env.Error{Name: "DB_NAME"}
 	}
+	if err := ValidateDBName(name); err != nil {
+		return fmt.Errorf("DB_NAME: %w", err)
+	}
 	d.Name = name
 
 	d.AllowWrite = false
@@ -78,18 +81,31 @@ func (d *Env) Populate() error {
 		d.AllowWrite = write
 	}
 
-	// Only do this for PostgreSQL driver as the MySQL driver will handle encoding.
-	if d.Driver == driverPostgreSQL {
+	// Escape for PostgreSQL URL userinfo. Compare via driver() so aliases
+	// ("postgres", "postgresql") are handled the same as "pgx".
+	if d.Driver.driver() == driverPostgreSQL {
 		d.Password = url.PathEscape(d.Password)
 	}
 
 	return nil
 }
 
+// ConnectionDSN builds a driver DSN. When dbName is non-empty it replaces
+// Env.Name. Callers accepting untrusted input MUST ValidateDBName first.
+// PostgreSQL database names are PathEscape'd so metacharacters cannot
+// introduce URL query parameters even if validation is skipped.
 func (d *Env) ConnectionDSN(dbName string) string {
+	name := d.Name
 	if dbName != "" {
-		return fmt.Sprintf(d.Driver.Format(), d.Username, d.Password, d.Host, d.Port, dbName)
-	} else {
-		return fmt.Sprintf(d.Driver.Format(), d.Username, d.Password, d.Host, d.Port, d.Name)
+		name = dbName
+	}
+
+	switch d.Driver.driver() {
+	case driverPostgreSQL:
+		return fmt.Sprintf(driverPostgreSQLFormat, d.Username, d.Password, d.Host, d.Port, url.PathEscape(name))
+	case driverMySQL:
+		return fmt.Sprintf(driverMySQLFormat, d.Username, d.Password, d.Host, d.Port, name)
+	default:
+		return fmt.Sprintf(d.Driver.Format(), d.Username, d.Password, d.Host, d.Port, name)
 	}
 }

--- a/pkg/env/db/dbname.go
+++ b/pkg/env/db/dbname.go
@@ -1,0 +1,21 @@
+package db
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// dbNamePattern is the allowlist for database names used in DSN construction.
+// Alphanumeric and underscore only, matching common MySQL/PostgreSQL unquoted
+// identifier rules and capping at the PostgreSQL NAMEDATALEN-1 limit (63).
+// Rejecting punctuation closes connection-string parameter injection (CWE-88)
+// via values such as "db?host=evil" or "db&allowAllFiles=true".
+var dbNamePattern = regexp.MustCompile(`^[A-Za-z0-9_]{1,63}$`)
+
+// ValidateDBName reports whether name is safe to interpolate into a driver DSN.
+func ValidateDBName(name string) error {
+	if !dbNamePattern.MatchString(name) {
+		return fmt.Errorf("invalid database name: must match %s", dbNamePattern.String())
+	}
+	return nil
+}

--- a/pkg/env/db/dbname_test.go
+++ b/pkg/env/db/dbname_test.go
@@ -1,0 +1,67 @@
+package db
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateDBName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		dbName  string
+		wantErr bool
+	}{
+		{name: "simple", dbName: "mydb", wantErr: false},
+		{name: "underscores and digits", dbName: "app_sre_db1", wantErr: false},
+		{name: "max length", dbName: strings.Repeat("a", 63), wantErr: false},
+		{name: "empty", dbName: "", wantErr: true},
+		{name: "too long", dbName: strings.Repeat("a", 64), wantErr: true},
+		{name: "query injection", dbName: "db?host=evil", wantErr: true},
+		{name: "ampersand injection", dbName: "db&allowAllFiles=true", wantErr: true},
+		{name: "slash", dbName: "db/name", wantErr: true},
+		{name: "space", dbName: "my db", wantErr: true},
+		{name: "hyphen", dbName: "my-db", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateDBName(tc.dbName)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestConnectionDSNRejectsInjectionViaPathEscape(t *testing.T) {
+	t.Parallel()
+
+	env := &Env{
+		Driver:   "pgx",
+		Host:     "db.example",
+		Port:     5432,
+		Username: "user",
+		Password: "secret",
+		Name:     "main",
+	}
+
+	// Even without ValidateDBName, PathEscape encodes '?' so it cannot start a
+	// URL query component. ('=' remains literal inside the path segment.)
+	dsn := env.ConnectionDSN("evil?host=attacker.example")
+	assert.Equal(t, "postgres://user:secret@db.example:5432/evil%3Fhost=attacker.example", dsn)
+	assert.NotContains(t, dsn, "?host=")
+	u, err := url.Parse(dsn)
+	require.NoError(t, err)
+	assert.Empty(t, u.RawQuery)
+	assert.Equal(t, "/evil%3Fhost=attacker.example", u.EscapedPath())
+}

--- a/pkg/gabi.go
+++ b/pkg/gabi.go
@@ -21,6 +21,15 @@ const (
 
 	// The total time it takes to execute the request.
 	DefaultRequestTimeout = 2 * time.Minute
+
+	// MaxRequestBodyBytes caps JSON request bodies buffered by middleware and
+	// handlers (SQL query payloads, db-switch requests). Sized for legitimate
+	// break-glass SQL while preventing memory-exhaustion DoS against the
+	// typically single-replica pod (FIND-005).
+	MaxRequestBodyBytes = 1 << 20 // 1 MiB
+
+	// MaxHeaderBytes limits request header size on the HTTP server.
+	MaxHeaderBytes = 1 << 20 // 1 MiB
 )
 
 type Config struct {
@@ -71,20 +80,24 @@ func parseDuration(duration string) (time.Duration, error) {
 }
 
 func (c *Config) OverrideDBName(dbName string) error {
+	if err := db.ValidateDBName(dbName); err != nil {
+		return err
+	}
+
 	c.Lock()
 	defer c.Unlock()
-	db, err := SQLOpen(c.DBEnv.Driver.String(), c.DBEnv.ConnectionDSN(dbName))
+	dbConn, err := SQLOpen(c.DBEnv.Driver.String(), c.DBEnv.ConnectionDSN(dbName))
 	if err != nil {
 		return err
 	}
-	err = db.Ping()
+	err = dbConn.Ping()
 	if err != nil {
-		db.Close()
+		_ = dbConn.Close()
 		return err
 	}
 	c.Logger.Debugf("Connected to database host: %s (dbname: %s)", c.DBEnv.Host, dbName)
-	c.DB.Close()
-	c.DB = db
+	_ = c.DB.Close()
+	c.DB = dbConn
 	c.DBEnv.Name = dbName
 	return nil
 }

--- a/pkg/gabi.go
+++ b/pkg/gabi.go
@@ -80,6 +80,8 @@ func parseDuration(duration string) (time.Duration, error) {
 }
 
 func (c *Config) OverrideDBName(dbName string) error {
+	// Defence-in-depth: callers (e.g. SwitchDBName handler) may have already
+	// validated, but this method is public so we guard unconditionally.
 	if err := db.ValidateDBName(dbName); err != nil {
 		return err
 	}

--- a/pkg/handlers/switchdbname.go
+++ b/pkg/handlers/switchdbname.go
@@ -2,29 +2,74 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"net/http"
+	"time"
 
 	gabi "github.com/app-sre/gabi/pkg"
+	"github.com/app-sre/gabi/pkg/audit"
+	"github.com/app-sre/gabi/pkg/env/db"
+	"github.com/app-sre/gabi/pkg/middleware"
 	"github.com/app-sre/gabi/pkg/models"
 )
 
 func SwitchDBName(cfg *gabi.Config) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, _ := r.Context().Value(middleware.ContextKeyUser).(string)
+		if user == "" {
+			http.Error(w, "Request cannot be authorized", http.StatusUnauthorized)
+			return
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, gabi.MaxRequestBodyBytes)
+
 		var req models.SwitchDBNameRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		dec := json.NewDecoder(r.Body)
+		if err := dec.Decode(&req); err != nil {
+			var maxBytesErr *http.MaxBytesError
+			if errors.As(err, &maxBytesErr) {
+				http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
+				return
+			}
+			http.Error(w, "Invalid request payload", http.StatusBadRequest)
+			return
+		}
+		// Reject trailing junk after the first JSON value.
+		if err := dec.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
 			http.Error(w, "Invalid request payload", http.StatusBadRequest)
 			return
 		}
 
-		err := cfg.OverrideDBName(req.DBName)
-		if err != nil {
+		if err := db.ValidateDBName(req.DBName); err != nil {
+			cfg.Logger.Errorf("Rejected database switch: %s", err)
+			http.Error(w, "Invalid database name", http.StatusBadRequest)
+			return
+		}
+
+		// Audit before mutation (fail closed), matching /query behavior.
+		query := &audit.QueryData{
+			Query:     fmt.Sprintf("SWITCH DATABASE %s", req.DBName),
+			User:      user,
+			Timestamp: time.Now().Unix(),
+		}
+		_ = cfg.LoggerAudit.Write(r.Context(), query)
+		if err := cfg.SplunkAudit.Write(r.Context(), query); err != nil {
+			cfg.Logger.Errorf("Unable to send audit to Splunk: %s", err)
+			http.Error(w, "An internal error has occurred", http.StatusInternalServerError)
+			return
+		}
+
+		if err := cfg.OverrideDBName(req.DBName); err != nil {
 			l := "Unable to open database connection"
 			cfg.Logger.Errorf("%s: %s", l, err)
 			http.Error(w, l, http.StatusBadRequest)
 			return
 		}
+
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]string{"db_name": cfg.GetCurrentDBName()})
+		_ = json.NewEncoder(w).Encode(map[string]string{"db_name": cfg.GetCurrentDBName()})
 	})
 }

--- a/pkg/handlers/switchdbname.go
+++ b/pkg/handlers/switchdbname.go
@@ -70,6 +70,6 @@ func SwitchDBName(cfg *gabi.Config) http.Handler {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]string{"db_name": cfg.GetCurrentDBName()})
+		_ = json.NewEncoder(w).Encode(models.DBNameResponse{DBName: cfg.GetCurrentDBName()})
 	})
 }

--- a/pkg/handlers/switchdbname_test.go
+++ b/pkg/handlers/switchdbname_test.go
@@ -3,63 +3,115 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"database/sql"
-	"errors"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/app-sre/gabi/internal/test"
 	gabi "github.com/app-sre/gabi/pkg"
+	"github.com/app-sre/gabi/pkg/audit"
 	"github.com/app-sre/gabi/pkg/env/db"
+	"github.com/app-sre/gabi/pkg/middleware"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+type nopAudit struct{}
+
+func (nopAudit) Write(context.Context, *audit.QueryData) error { return nil }
+
+type errAudit struct{ err error }
+
+func (a errAudit) Write(context.Context, *audit.QueryData) error { return a.err }
+
 func TestSwitchDBName(t *testing.T) {
 	cases := []struct {
-		description   string
+		description string
 		initialDBName string
 		newDBName     string
+		rawBody       []byte
 		sqlOpener     func(string, string) (*sql.DB, error)
+		splunkAudit   audit.Audit
+		withUser      bool
 		code          int
 		body          map[string]string
 	}{
 		{
-			"override database name",
-			"initial_db",
-			"new_db",
-			func(s string, s2 string) (db *sql.DB, err error) {
-				new_db, mock, _ := sqlmock.New(sqlmock.MonitorPingsOption(true))
+			description:   "override database name",
+			initialDBName: "initial_db",
+			newDBName:     "new_db",
+			sqlOpener: func(string, string) (*sql.DB, error) {
+				newDB, mock, _ := sqlmock.New(sqlmock.MonitorPingsOption(true))
 				mock.ExpectPing()
-				return new_db, nil
-            },
-			200,
-			map[string]string{"db_name": "new_db"},
+				return newDB, nil
+			},
+			splunkAudit: nopAudit{},
+			withUser:    true,
+			code:        200,
+			body:        map[string]string{"db_name": "new_db"},
 		},
 		{
-			"invalid database name",
-			"initial_db",
-			"invalid_db",
-			func(s string, s2 string) (db *sql.DB, err error) {
-				new_db, _, _ := sqlmock.New()				
-				return new_db, errors.New("connection refused")
-            },
-			400,
-			map[string]string{"error": "Unable to open database connection"},
+			description:   "connection failure",
+			initialDBName: "initial_db",
+			newDBName:     "other_db",
+			sqlOpener: func(string, string) (*sql.DB, error) {
+				return nil, errors.New("connection refused")
+			},
+			splunkAudit: nopAudit{},
+			withUser:    true,
+			code:        400,
+			body:        map[string]string{"error": "Unable to open database connection"},
 		},
 		{
-			"invalid request payload",
-			"initial_db",
-			"",
-			func(s string, s2 string) (db *sql.DB, err error) {
+			description:   "invalid request payload",
+			initialDBName: "initial_db",
+			rawBody:       []byte(`invalid payload`),
+			sqlOpener:     func(string, string) (*sql.DB, error) { return nil, nil },
+			splunkAudit:   nopAudit{},
+			withUser:      true,
+			code:          400,
+			body:          map[string]string{"error": "Invalid request payload"},
+		},
+		{
+			description:   "reject DSN injection in db_name",
+			initialDBName: "initial_db",
+			newDBName:     "evil?host=attacker.example",
+			sqlOpener: func(string, string) (*sql.DB, error) {
+				t.Fatal("SQLOpen must not be called for invalid db_name")
 				return nil, nil
-            },
-			400,
-			map[string]string{"error": "Invalid request payload"},
+			},
+			splunkAudit: nopAudit{},
+			withUser:    true,
+			code:        400,
+			body:        map[string]string{"error": "Invalid database name"},
+		},
+		{
+			description:   "reject missing authorized user",
+			initialDBName: "initial_db",
+			newDBName:     "new_db",
+			sqlOpener:     func(string, string) (*sql.DB, error) { return nil, nil },
+			splunkAudit:   nopAudit{},
+			withUser:      false,
+			code:          401,
+			body:          map[string]string{"error": "Request cannot be authorized"},
+		},
+		{
+			description:   "fail closed when Splunk audit fails",
+			initialDBName: "initial_db",
+			newDBName:     "new_db",
+			sqlOpener: func(string, string) (*sql.DB, error) {
+				t.Fatal("SQLOpen must not be called when audit fails")
+				return nil, nil
+			},
+			splunkAudit: errAudit{err: errors.New("splunk down")},
+			withUser:    true,
+			code:        500,
+			body:        map[string]string{"error": "An internal error has occurred"},
 		},
 	}
 
@@ -68,44 +120,51 @@ func TestSwitchDBName(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			var body bytes.Buffer
 
-			dbEnv := &db.Env{Name: tc.initialDBName}
-			db, _, _ := sqlmock.New()
+			dbEnv := &db.Env{Name: tc.initialDBName, Driver: "pgx", Host: "localhost", Port: 5432}
+			sqlDB, _, _ := sqlmock.New()
 
 			w := httptest.NewRecorder()
-			var requestBody []byte
-			if tc.description == "invalid request payload" {
-				requestBody = []byte(`invalid payload`)
-			} else {
+			requestBody := tc.rawBody
+			if requestBody == nil {
 				requestBody, _ = json.Marshal(map[string]string{"db_name": tc.newDBName})
 			}
 			r := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(requestBody))
+			ctx := context.TODO()
+			if tc.withUser {
+				ctx = context.WithValue(ctx, middleware.ContextKeyUser, "test-user")
+			}
+			r = r.WithContext(ctx)
 
 			logger := test.DummyLogger(io.Discard).Sugar()
-
-			expected := &gabi.Config{DB: db, DBEnv: dbEnv, Logger: logger}
+			expected := &gabi.Config{
+				DB:          sqlDB,
+				DBEnv:       dbEnv,
+				Logger:      logger,
+				LoggerAudit: nopAudit{},
+				SplunkAudit: tc.splunkAudit,
+			}
 			defer func() { _ = expected.DB.Close() }()
 
 			gabi.SQLOpen = tc.sqlOpener
-			SwitchDBName(expected).ServeHTTP(w, r.WithContext(context.TODO()))
+			SwitchDBName(expected).ServeHTTP(w, r)
 
 			actual := w.Result()
 			defer func() { _ = actual.Body.Close() }()
 
 			_, _ = io.Copy(&body, actual.Body)
+			assert.Equal(t, tc.code, actual.StatusCode)
 
-			var responseBody map[string]string
-			err := json.Unmarshal(body.Bytes(), &responseBody)
-
-			if tc.description == "override database name" {
+			if tc.code == 200 {
+				var responseBody map[string]string
+				err := json.Unmarshal(body.Bytes(), &responseBody)
 				require.NoError(t, err)
-				assert.Equal(t, tc.code, actual.StatusCode)
 				assert.Equal(t, tc.body, responseBody)
 				assert.Equal(t, tc.newDBName, expected.GetCurrentDBName())
-			} else {
-				require.Error(t, err)
-				assert.Equal(t, tc.code, actual.StatusCode)
-				assert.Contains(t, body.String(), tc.body["error"])
+				return
 			}
+
+			assert.Contains(t, body.String(), tc.body["error"])
+			assert.Equal(t, tc.initialDBName, expected.GetCurrentDBName())
 		})
 	}
 }

--- a/pkg/middleware/audit.go
+++ b/pkg/middleware/audit.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -22,7 +23,6 @@ func Audit(cfg *gabi.Config) Middleware {
 			now := time.Now()
 
 			var (
-				b       bytes.Buffer
 				request models.QueryRequest
 				user    string
 			)
@@ -30,6 +30,12 @@ func Audit(cfg *gabi.Config) Middleware {
 			if s := r.Header.Get(contentLengthHeader); s == "" {
 				l := fmt.Sprintf("Request without required header: %s", contentLengthHeader)
 				http.Error(w, l, http.StatusBadRequest)
+				return
+			}
+
+			// Cheap reject before buffering when the client declared an oversized body.
+			if r.ContentLength > gabi.MaxRequestBodyBytes {
+				http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
 				return
 			}
 
@@ -53,16 +59,21 @@ func Audit(cfg *gabi.Config) Middleware {
 				return
 			}
 
-			if _, err := io.Copy(&b, r.Body); err != nil {
+			body, err := readLimitedBody(w, r, gabi.MaxRequestBodyBytes)
+			if err != nil {
+				var maxBytesErr *http.MaxBytesError
+				if errors.As(err, &maxBytesErr) {
+					http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
+					return
+				}
 				cfg.Logger.Errorf("Unable to copy request body: %s", err)
 				http.Error(w, "An internal error has occurred", http.StatusInternalServerError)
 				return
 			}
-			_ = r.Body.Close()
 
-			r.Body = io.NopCloser(bytes.NewReader(b.Bytes()))
+			r.Body = io.NopCloser(bytes.NewReader(body))
 
-			err := json.Unmarshal(b.Bytes(), &request)
+			err = json.Unmarshal(body, &request)
 			if err != nil {
 				cfg.Logger.Debugf("Unable to unmarshal request body: %s", err)
 				h.ServeHTTP(w, r)
@@ -70,14 +81,14 @@ func Audit(cfg *gabi.Config) Middleware {
 			}
 
 			if base64DecodeQuery {
-				bytes, err := cfg.Encoder.DecodeString(request.Query)
+				decoded, err := cfg.Encoder.DecodeString(request.Query)
 				if err != nil {
 					l := "Unable to decode Base64-encoded query"
 					cfg.Logger.Errorf("%s: %s", l, err)
 					http.Error(w, l, http.StatusBadRequest)
 					return
 				}
-				request.Query = string(bytes)
+				request.Query = string(decoded)
 			}
 
 			query := &audit.QueryData{
@@ -97,4 +108,22 @@ func Audit(cfg *gabi.Config) Middleware {
 			h.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
+}
+
+// readLimitedBody copies r.Body into memory with an hard upper bound. It always
+// installs http.MaxBytesReader so chunked requests without a truthful
+// Content-Length cannot bypass the cap.
+func readLimitedBody(w http.ResponseWriter, r *http.Request, max int64) ([]byte, error) {
+	r.Body = http.MaxBytesReader(w, r.Body, max)
+	var b bytes.Buffer
+	// Pre-size when Content-Length is trustworthy to reduce reallocations.
+	if r.ContentLength > 0 && r.ContentLength <= max {
+		b.Grow(int(r.ContentLength))
+	}
+	if _, err := io.Copy(&b, r.Body); err != nil {
+		_ = r.Body.Close()
+		return nil, err
+	}
+	_ = r.Body.Close()
+	return b.Bytes(), nil
 }

--- a/pkg/middleware/audit_test.go
+++ b/pkg/middleware/audit_test.go
@@ -446,6 +446,37 @@ func TestAudit(t *testing.T) {
 			``,
 		},
 		{
+			"reject oversized request body",
+			func(s *httptest.Server) *splunk.Env {
+				return &splunk.Env{
+					Endpoint: s.URL,
+				}
+			},
+			func() context.Context {
+				return context.TODO()
+			},
+			func(b *bytes.Buffer) func(r *http.Request) {
+				return func(r *http.Request) {
+					r.Header.Set("Content-Length", fmt.Sprint(b.Len()))
+					r.Header.Set("X-Forwarded-User", "test")
+				}
+			},
+			func() *bytes.Buffer {
+				// Just over MaxRequestBodyBytes (1 MiB).
+				return bytes.NewBuffer(bytes.Repeat([]byte("a"), int(gabi.MaxRequestBodyBytes)+1))
+			},
+			func(b *bytes.Buffer) func(w http.ResponseWriter, r *http.Request) {
+				return func(w http.ResponseWriter, r *http.Request) {
+					// Must not run.
+				}
+			},
+			http.StatusRequestEntityTooLarge,
+			`Request body too large`,
+			``,
+			regexp.MustCompile(``),
+			``,
+		},
+		{
 			"invalid query with malformed Base64-encoded value in the body",
 			func(s *httptest.Server) *splunk.Env {
 				return &splunk.Env{


### PR DESCRIPTION
## Summary
Remediates Glasswing Medium findings FIND-002, FIND-003, and FIND-005 for [gabi](https://github.com/app-sre/gabi) ([APPSRE-15060](https://redhat.atlassian.net/browse/APPSRE-15060)).

- **FIND-002:** Wrap `/dbname` and `/dbname/switch` in Authorization + Expiration (switch also Timeout); emit fail-closed Splunk audit before mutating process-global `cfg.DB`
- **FIND-003:** Allowlist `db_name` (`^[A-Za-z0-9_]{1,63}$`) and path-escape the PostgreSQL DSN database segment to block connection-string parameter injection
- **FIND-005:** Cap buffered request bodies at 1 MiB (`http.MaxBytesReader` + early Content-Length reject → 413); set `MaxHeaderBytes` on the HTTP server

FIND-001 was previously fixed in #164 / APPSRE-15020. FIND-004 and FIND-006–010 are out of scope for this PR.

## Patch efficacy

| Finding | Pre-fix risk (post-FIND-001) | How this PR closes it | Residual notes |
|---|---|---|---|
| **FIND-002** | Any oauth-proxy-authenticated namespace user (not on gabi allowlist) could read/switch the shared DB with no audit trail | Routes now require allowlisted `X-Forwarded-User` + non-expired config; switch writes Splunk/console audit **before** mutate and fails closed on audit error | Callers must still clear oauth-proxy; that is intentional |
| **FIND-003** | `db_name` like `evil?host=attacker` could redirect the credentialed DSN | Allowlist rejects metacharacters; Postgres path segment is `url.PathEscape`d so `?` cannot open a query component; invalid names never reach `sql.Open` | Hyphenated DB names are rejected by design |
| **FIND-005** | Allowlisted caller could stream an unbounded body and OOM the ~256Mi pod | Bodies capped at 1 MiB (declared Content-Length + `MaxBytesReader`); oversize → **413**; server `MaxHeaderBytes` set | Large **result sets** are a separate concern (`/query` vs `/streamquery`), not this finding |

## Local verification (2026-08-11, commit `80bcb38`)

Ran on branch `fix/APPSRE-15060`:

```text
make build   # pass
go vet ./... # pass
make test    # pass (go test ./...)
```

Security-focused unit coverage exercised and passing:

- `TestValidateDBName` / `TestConnectionDSNRejectsInjectionViaPathEscape` (FIND-003)
- `TestSwitchDBName` — auth required, DSN injection rejected, Splunk audit fail-closed (FIND-002/003)
- `TestAudit/reject_oversized_request_body` → 413 (FIND-005)

Kind/cluster integration tests were **not** run for this change (unit coverage is sufficient for these three findings).

## Test plan
- [x] Unit tests: `make test` / `go test ./...` (local, pass)
- [x] `make build` and `go vet ./...` (local, pass)
- [x] Injection-shaped `db_name` (e.g. `evil?host=attacker`) returns 400 and never opens a DB connection (unit)
- [x] Oversized POST body to Audit path returns 413 (unit)
- [x] Switch without authorized user is rejected; Splunk audit failure blocks switch (unit)
- [ ] Confirm in a live/deployed environment that non-allowlisted oauth-proxy users cannot call `/dbname` or `/dbname/switch`
- [ ] Confirm successful `/dbname/switch` produces a Splunk audit event end-to-end

JIRA: https://redhat.atlassian.net/browse/APPSRE-15060