### PR TITLE
fix: allow hyphens in database names (APPSRE-15158)

### DIFF
--- a/pkg/env/db/dbname.go
+++ b/pkg/env/db/dbname.go
@@ -6,11 +6,12 @@ import (
 )
 
 // dbNamePattern is the allowlist for database names used in DSN construction.
-// Alphanumeric and underscore only, matching common MySQL/PostgreSQL unquoted
-// identifier rules and capping at the PostgreSQL NAMEDATALEN-1 limit (63).
-// Rejecting punctuation closes connection-string parameter injection (CWE-88)
-// via values such as "db?host=evil" or "db&allowAllFiles=true".
-var dbNamePattern = regexp.MustCompile(`^[A-Za-z0-9_]{1,63}$`)
+// Letters, digits, underscore, and hyphen (not as the first character), capped
+// at the PostgreSQL NAMEDATALEN-1 limit (63). Hyphens are valid in quoted
+// MySQL/PostgreSQL database names and are not DSN metacharacters.
+// Rejecting other punctuation closes connection-string parameter injection
+// (CWE-88) via values such as "db?host=evil" or "db&allowAllFiles=true".
+var dbNamePattern = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_-]{0,62}$`)
 
 // ValidateDBName reports whether name is safe to interpolate into a driver DSN.
 func ValidateDBName(name string) error {

--- a/pkg/env/db/dbname_test.go
+++ b/pkg/env/db/dbname_test.go
@@ -19,14 +19,16 @@ func TestValidateDBName(t *testing.T) {
 	}{
 		{name: "simple", dbName: "mydb", wantErr: false},
 		{name: "underscores and digits", dbName: "app_sre_db1", wantErr: false},
+		{name: "hyphen", dbName: "my-db", wantErr: false},
+		{name: "hyphenated production name", dbName: "rhsm-subscriptions", wantErr: false},
 		{name: "max length", dbName: strings.Repeat("a", 63), wantErr: false},
 		{name: "empty", dbName: "", wantErr: true},
 		{name: "too long", dbName: strings.Repeat("a", 64), wantErr: true},
+		{name: "leading hyphen", dbName: "-mydb", wantErr: true},
 		{name: "query injection", dbName: "db?host=evil", wantErr: true},
 		{name: "ampersand injection", dbName: "db&allowAllFiles=true", wantErr: true},
 		{name: "slash", dbName: "db/name", wantErr: true},
 		{name: "space", dbName: "my db", wantErr: true},
-		{name: "hyphen", dbName: "my-db", wantErr: true},
 	}
 
 	for _, tc := range cases {
@@ -64,4 +66,23 @@ func TestConnectionDSNRejectsInjectionViaPathEscape(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, u.RawQuery)
 	assert.Equal(t, "/evil%3Fhost=attacker.example", u.EscapedPath())
+}
+
+func TestConnectionDSNPreservesHyphenatedDBName(t *testing.T) {
+	t.Parallel()
+
+	env := &Env{
+		Driver:   "pgx",
+		Host:     "db.example",
+		Port:     5432,
+		Username: "user",
+		Password: "secret",
+		Name:     "main",
+	}
+
+	dsn := env.ConnectionDSN("rhsm-subscriptions")
+	assert.Equal(t, "postgres://user:secret@db.example:5432/rhsm-subscriptions", dsn)
+	u, err := url.Parse(dsn)
+	require.NoError(t, err)
+	assert.Equal(t, "rhsm-subscriptions", strings.TrimPrefix(u.Path, "/"))
 }


### PR DESCRIPTION
## Summary
- Subscription Watch production GABI crash-loops because `DB_NAME=rhsm-subscriptions` fails the FIND-003 allowlist added in https://github.com/app-sre/gabi/pull/165.
- Hyphens are valid in quoted PostgreSQL/MySQL database names and are not DSN metacharacters (`?`, `&`, `/`, space still rejected).
- Widen validation to `^[A-Za-z0-9_][A-Za-z0-9_-]{0,62}$` so `rhsm-subscriptions` is accepted at startup and on `/dbname/switch`.

JIRA: https://issues.redhat.com/browse/APPSRE-15158

## Test plan
- [x] `go test ./pkg/env/db/ ./pkg/handlers/`
- [x] `make test` (`go test ./...`)
- [ ] After merge: confirm Subscription Watch GABI starts against `rhsm-subscriptions` once the image is promoted